### PR TITLE
Implement compiler scaffolding for nogc exceptions

### DIFF
--- a/dmd2/declaration.c
+++ b/dmd2/declaration.c
@@ -1597,7 +1597,8 @@ void VarDeclaration::semantic2(Scope *sc)
     }
     else if (init && isThreadlocal())
     {
-        if ((type->ty == Tclass) && type->isMutable() && !type->isShared())
+        // weka.io patch: allow thread-local globals/statics if it's a throwable (exception/error)
+        if ((type->ty == Tclass) && type->isMutable() && !type->isShared() && !ClassDeclaration::throwable->isBaseOf(type->isClassHandle(), NULL))
         {
             ExpInitializer *ei = init->isExpInitializer();
             if (ei && ei->exp->op == TOKclassreference)

--- a/gen/llvmhelpers.h
+++ b/gen/llvmhelpers.h
@@ -230,6 +230,9 @@ DValue *toElem(Expression *e, bool tryGetLvalue);
 DValue *toElemDtor(Expression *e);
 LLConstant *toConstElem(Expression *e, IRState *p);
 
+llvm::CallInst* generateExceptionIncRef();
+llvm::CallInst* generateExceptionDecRef();
+
 #if LDC_LLVM_VER >= 307
 bool supportsCOMDAT();
 

--- a/gen/runtime.cpp
+++ b/gen/runtime.cpp
@@ -241,7 +241,8 @@ static void LLVM_D_BuildRuntimeModule()
     LLType* longTy = LLType::getInt64Ty(gIR->context());
     LLType* sizeTy = DtoSize_t();
 
-    LLType* voidPtrTy = rt_ptr(byteTy);
+    LLType* voidPtrTy = rt_ptr(voidTy);
+    LLType* voidPtrPtrTy = rt_ptr(voidPtrTy);
     LLType* voidArrayTy = rt_array(byteTy);
     LLType* voidArrayPtrTy = rt_ptr(voidArrayTy);
     LLType* stringTy = DtoType(Type::tchar->arrayOf());
@@ -888,7 +889,7 @@ static void LLVM_D_BuildRuntimeModule()
     /////////////////////////////////////////////////////////////////////////////////////
     /////////////////////////////////////////////////////////////////////////////////////
 
-    // void _d_throw_exception(Object e)
+    // void _d_throw_exception(Object e) @nogc
     {
         llvm::StringRef fname("_d_throw_exception");
         LLType *types[] = { objectTy };
@@ -960,7 +961,7 @@ static void LLVM_D_BuildRuntimeModule()
         llvm::Function::Create(fty, llvm::GlobalValue::ExternalLinkage, fname, M);
     }
 
-    // void _d_eh_resume_unwind(ptr exc_struct)
+    // void _d_eh_resume_unwind(ptr exc_struct) @nogc
     {
         llvm::StringRef fname("_d_eh_resume_unwind");
         LLType *types[] = { voidPtrTy };
@@ -968,7 +969,23 @@ static void LLVM_D_BuildRuntimeModule()
         llvm::Function::Create(fty, llvm::GlobalValue::ExternalLinkage, fname, M);
     }
 
-    // void _d_eh_enter_catch()
+    // void _d_eh_exception_incref(_d_exception** exc_struct) @nogc
+    {
+        llvm::StringRef fname("_d_eh_exception_incref");
+        LLType *types[] = { voidPtrPtrTy };
+        LLFunctionType* fty = llvm::FunctionType::get(voidTy, types, false);
+        llvm::Function::Create(fty, llvm::GlobalValue::ExternalLinkage, fname, M);
+    }
+
+    // void _d_eh_exception_decref(_d_exception** exc_struct) @nogc
+    {
+        llvm::StringRef fname("_d_eh_exception_decref");
+        LLType *types[] = { voidPtrPtrTy };
+        LLFunctionType* fty = llvm::FunctionType::get(voidTy, types, false);
+        llvm::Function::Create(fty, llvm::GlobalValue::ExternalLinkage, fname, M);
+    }
+
+    // void _d_eh_enter_catch() @nogc
     {
         llvm::StringRef fname("_d_eh_enter_catch");
         LLFunctionType* fty = llvm::FunctionType::get(voidTy, false);

--- a/ir/irfunction.cpp
+++ b/ir/irfunction.cpp
@@ -337,6 +337,10 @@ llvm::BasicBlock* ScopeStack::emitLandingPad() {
 
         irs->scope() = IRScope(oldBB);
     }
+    // Decrease the reference count on the already existing eh.ptr; this
+    // solves the issue in which the eh.ptr was never freed if a new exception
+    // was thrown in the same function
+    generateExceptionDecRef();
     irs->ir->CreateStore(ehPtr, irs->func()->getOrCreateEhPtrSlot());
 
     llvm::Value* ehSelector = DtoExtractValue(landingPad, 1);
@@ -401,11 +405,21 @@ llvm::BasicBlock* ScopeStack::emitLandingPad() {
         irs->scopebb()->replaceAllUsesWith(irs->func()->resumeUnwindBlock);
         irs->scopebb()->eraseFromParent();
     } else {
+        landingPad->setCleanup(true);
         irs->ir->CreateBr(irs->func()->resumeUnwindBlock);
     }
 
     irs->scope() = savedIRScope;
     return beginBB;
+}
+
+bool ScopeStack::doesCalleeNeedInvoke(llvm::Function* calleeFn)
+{
+    // Intrinsics don't support invoking and 'nounwind' functions don't need it.
+    const bool doesNotThrow = calleeFn &&
+        (calleeFn->isIntrinsic() || calleeFn->doesNotThrow());
+
+    return !(doesNotThrow || (cleanupScopes.empty() && catchScopes.empty() && catchBlockCount == 0));
 }
 
 IrFunction::IrFunction(FuncDeclaration* fd) {
@@ -466,6 +480,10 @@ void IrFunction::setAlwaysInline() {
 llvm::AllocaInst* IrFunction::getOrCreateEhPtrSlot() {
     if (!ehPtrSlot) {
         ehPtrSlot = DtoRawAlloca(getVoidPtrType(), 0, "eh.ptr");
+        // Initialize eh.ptr to null
+        llvm::StoreInst* si = new llvm::StoreInst(
+            llvm::ConstantPointerNull::get(getVoidPtrType()), ehPtrSlot, gIR->topallocapoint());
+        (void)si;
     }
     return ehPtrSlot;
 }


### PR DESCRIPTION
- Allow throwing of static mutable exceptions (given they derive from Throwable)
- Implement reference counting scaffolding for _d_exception, allowing for the removal of GC allocations from exception handling (with the exception of TraceInfo, to be handled later)
