### PR TITLE
Yanok/ctfe fun attr 1.30

### DIFF
--- a/dmd/astenums.d
+++ b/dmd/astenums.d
@@ -111,12 +111,13 @@ enum STC : ulong  // transfer changes to declaration.h
     live                = 0x10_0000_0000_0000,   /// function `@live` attribute
     register            = 0x20_0000_0000_0000,   /// `register` storage class (ImportC)
     volatile_           = 0x40_0000_0000_0000,   /// destined for volatile in the back end
+    ctonly              = 0x80_0000_0000_0000,   /// function that is only called during compile time
 
     safeGroup = STC.safe | STC.trusted | STC.system,
     IOR  = STC.in_ | STC.ref_ | STC.out_,
     TYPECTOR = (STC.const_ | STC.immutable_ | STC.shared_ | STC.wild),
     FUNCATTR = (STC.ref_ | STC.nothrow_ | STC.nogc | STC.pure_ | STC.property | STC.live |
-                safeGroup),
+                safeGroup | STC.ctonly),
 
     /* These are visible to the user, i.e. are expressed by the user
      */
@@ -124,7 +125,7 @@ enum STC : ulong  // transfer changes to declaration.h
         (STC.auto_ | STC.scope_ | STC.static_ | STC.extern_ | STC.const_ | STC.final_ | STC.abstract_ | STC.synchronized_ |
          STC.deprecated_ | STC.future | STC.override_ | STC.lazy_ | STC.alias_ | STC.out_ | STC.in_ | STC.manifest |
          STC.immutable_ | STC.shared_ | STC.wild | STC.nothrow_ | STC.nogc | STC.pure_ | STC.ref_ | STC.return_ | STC.tls | STC.gshared |
-         STC.property | STC.safeGroup | STC.disable | STC.local | STC.live),
+         STC.property | STC.safeGroup | STC.disable | STC.local | STC.live | STC.ctonly),
 
     /* These storage classes "flow through" to the inner scope of a Dsymbol
      */

--- a/dmd/declaration.h
+++ b/dmd/declaration.h
@@ -100,9 +100,10 @@ struct IntRange;
     #define STClive               0x10000000000000ULL    /// function `@live` attribute
     #define STCregister           0x20000000000000ULL    /// `register` storage class (ImportC)
     #define STCvolatile           0x40000000000000ULL    /// destined for volatile in the back end
+    #define STCctonly             0x80000000000000ULL    /// function that is only called during compile time
 
 #define STC_TYPECTOR    (STCconst | STCimmutable | STCshared | STCwild)
-#define STC_FUNCATTR    (STCref | STCnothrow | STCnogc | STCpure | STCproperty | STCsafe | STCtrusted | STCsystem)
+#define STC_FUNCATTR    (STCref | STCnothrow | STCnogc | STCpure | STCproperty | STCsafe | STCtrusted | STCsystem | STCctonly)
 
 void ObjectNotFound(Identifier *id);
 

--- a/dmd/expressionsem.d
+++ b/dmd/expressionsem.d
@@ -13106,6 +13106,7 @@ private bool checkFunctionAttributes(Expression exp, Scope* sc, FuncDeclaration 
         error |= checkPurity(sc, f);
         error |= checkSafety(sc, f);
         error |= checkNogc(sc, f);
+        error |= checkCtonly(f, exp.loc, sc);
         return error;
     }
 }

--- a/dmd/hdrgen.d
+++ b/dmd/hdrgen.d
@@ -2937,6 +2937,7 @@ string stcToString(ref StorageClass stc)
         SCstring(STC.disable, "@disable"),
         SCstring(STC.future, "@__future"),
         SCstring(STC.local, "__local"),
+        SCstring(STC.ctonly, "@__ctfe"),
     ];
     foreach (ref entry; table)
     {

--- a/dmd/mtype.d
+++ b/dmd/mtype.d
@@ -4241,6 +4241,7 @@ extern (C++) final class TypeFunction : TypeNext
         bool isctor;           /// the function is a constructor
         bool isreturnscope;    /// `this` is returned by value
         bool isCtonly;         /// is compile time only (@__ctfe)
+        bool isCtonlyInferred; /// was compile time only inferred
     }
 
     import dmd.common.bitfields : generateBitFields;
@@ -4251,6 +4252,7 @@ extern (C++) final class TypeFunction : TypeNext
     PURE purity = PURE.impure;
     byte inuse;
     Expressions* fargs;         // function arguments
+    FuncDeclaration ctOnlyInferReason = null;
 
     extern (D) this(ParameterList pl, Type treturn, LINK linkage, StorageClass stc = 0)
     {

--- a/dmd/mtype.d
+++ b/dmd/mtype.d
@@ -4240,6 +4240,7 @@ extern (C++) final class TypeFunction : TypeNext
         bool isInOutQual;      /// inout on the qualifier
         bool isctor;           /// the function is a constructor
         bool isreturnscope;    /// `this` is returned by value
+        bool isCtonly;         /// is compile time only (@__ctfe)
     }
 
     import dmd.common.bitfields : generateBitFields;
@@ -4270,6 +4271,8 @@ extern (C++) final class TypeFunction : TypeNext
             this.isproperty = true;
         if (stc & STC.live)
             this.islive = true;
+        if (stc & STC.ctonly)
+            this.isCtonly = true;
 
         if (stc & STC.ref_)
             this.isref = true;
@@ -4324,6 +4327,7 @@ extern (C++) final class TypeFunction : TypeNext
         t.trust = trust;
         t.fargs = fargs;
         t.isctor = isctor;
+        t.isCtonly = isCtonly;
         return t;
     }
 
@@ -7189,6 +7193,8 @@ void attributesApply(const TypeFunction tf, void delegate(string) dg, TRUSTforma
         dg("scope");
     if (tf.islive)
         dg("@live");
+    if (tf.isCtonly)
+        dg("@__ctfe");
 
     TRUST trustAttrib = tf.trust;
 

--- a/dmd/mtype.h
+++ b/dmd/mtype.h
@@ -647,6 +647,8 @@ public:
     bool isInOutQual() const;
     void isInOutQual(bool v);
     bool iswild() const;
+    bool isCtonly() const;
+    void isCtonly(bool v);
 
     void accept(Visitor *v) { v->visit(this); }
 };

--- a/dmd/parse.d
+++ b/dmd/parse.d
@@ -9318,6 +9318,7 @@ LagainStc:
                (ident == Id.live)     ? STC.live     :
                (ident == Id.future)   ? STC.future   :
                (ident == Id.disable)  ? STC.disable  :
+               (ident == Id.ctfe)     ? STC.ctonly   :
                0;
     }
 

--- a/dmd/typesem.d
+++ b/dmd/typesem.d
@@ -1201,6 +1201,9 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
         if (sc.stc & STC.scopeinferred)
             tf.isscopeinferred = true;
 
+        if (sc.stc & STC.ctonly)
+            tf.isCtonly = true;
+
 //        if (tf.isreturn && !tf.isref)
 //            tf.isScopeQual = true;                                  // return by itself means 'return scope'
 

--- a/gen/declarations.cpp
+++ b/gen/declarations.cpp
@@ -290,6 +290,10 @@ public:
   //////////////////////////////////////////////////////////////////////////
 
   void visit(FuncDeclaration *decl) override {
+    auto type = decl->type;
+    if (type && type->toTypeFunction()->isCtonly()) {
+      return;
+    }
     // don't touch function aliases, they don't contribute any new symbols
     if (!decl->isFuncAliasDeclaration()) {
       DtoDefineFunction(decl);

--- a/gen/declarations.cpp
+++ b/gen/declarations.cpp
@@ -291,6 +291,7 @@ public:
 
   void visit(FuncDeclaration *decl) override {
     auto type = decl->type;
+    // don't generate code marked or inferred with @__ctfe
     if (type && type->toTypeFunction()->isCtonly()) {
       return;
     }

--- a/tests/compilable/ctonly_basic.d
+++ b/tests/compilable/ctonly_basic.d
@@ -1,3 +1,5 @@
+// RUN: %ldc -c %s
+
 int f(int x, int y) @__ctfe {
     return x + y;
 }

--- a/tests/compilable/ctonly_basic.d
+++ b/tests/compilable/ctonly_basic.d
@@ -1,0 +1,24 @@
+int f(int x, int y) @__ctfe {
+    return x + y;
+}
+
+int g(int x)(int y) @__ctfe {
+    return x + y;
+}
+
+alias gf = g!2;
+
+/* enums are fine */
+enum e = g!4(2);
+/* globals initializers are fine */
+int z = f(2, 5);
+
+void main() {
+    /* enums are fine */
+    enum x = f(2, 4);
+    enum y = gf(4);
+    /* static asserts are fine */
+    static assert (f(2, 2) == g!4(0));
+    /* array indeces are fine */
+    int[g!10(0)] arr;
+}

--- a/tests/compilable/ctonly_class.d
+++ b/tests/compilable/ctonly_class.d
@@ -1,3 +1,4 @@
+// RUN: %ldc -c %s
 
 class C {
     int v;

--- a/tests/compilable/ctonly_class.d
+++ b/tests/compilable/ctonly_class.d
@@ -1,0 +1,28 @@
+
+class C {
+    int v;
+    this(int v_) { v = v_; }
+    int f(int x) const @__ctfe { return x + v; }
+    static int g(int x) @__ctfe { return x + 2; }
+}
+
+class CtOnly {
+    int v;
+    this(int v_) @__ctfe { v = v_; }
+    int f(int x) const { return x + v; }
+    static int g(int x) { return x + 2; }
+}
+
+// can do this
+enum v = new C(1).f(0);
+// or this
+static const c = new C(2);
+enum v2 = c.f(2);
+
+void main() {
+    C i = new C(2);
+    // or this
+    enum v = C.g(2);
+    // or this
+    enum e = new CtOnly(5).f(5);
+}

--- a/tests/compilable/ctonly_simple_map.d
+++ b/tests/compilable/ctonly_simple_map.d
@@ -1,0 +1,51 @@
+
+import std.algorithm.searching;
+import std.range;
+import std.traits;
+
+/// Checks is a function is @ctonly
+enum isCtOnly(alias f) = canFind(only(__traits(getFunctionAttributes, f)), "@__ctfe");
+
+/// Simplified @ctonly-aware version of `map`
+auto simple_map(alias fun, Range)(Range r) {
+    return SimpleMapResult!(fun, Range)(r);
+}
+
+private struct SimpleMapResult(alias fun, Range) {
+    alias R = Unqual!Range;
+    enum funIsCtOnly = isCtOnly!fun;
+    R _input;
+    this(R input) {
+        _input = input;
+    }
+    void popFront() {
+        _input.popFront();
+    }
+    @property bool empty() {
+        return _input.empty;
+    }
+    static if (funIsCtOnly) {
+        /// If `fun` is @ctonly, `front` must be @ctonly too
+        @property auto ref front() @__ctfe {
+            return fun(_input.front);
+        }
+    } else {
+        @property auto ref front() {
+            return fun(_input.front);
+        }
+    }
+}
+
+int f(int x) @__ctfe {
+    return x + 1;
+}
+
+import std.algorithm.iteration;
+import std.array;
+
+void main() {
+    enum f2 = f(2);
+    // enum a = map!f([1, 2, 3]).array; // doesn't work
+    enum a2 = simple_map!f([1, 2, 3]); // that works
+    enum a2f = a2.front; // that works too, even though `a2.array` won't work, since `array` must be @ctonly-aware as well
+}

--- a/tests/compilable/ctonly_simple_map.d
+++ b/tests/compilable/ctonly_simple_map.d
@@ -1,3 +1,4 @@
+// RUN: %ldc -c %s
 
 import std.algorithm.searching;
 import std.range;

--- a/tests/compilable/ctonly_templates.d
+++ b/tests/compilable/ctonly_templates.d
@@ -1,3 +1,5 @@
+// RUN: %ldc -c %s
+
 import std.algorithm.iteration;
 import std.array;
 

--- a/tests/compilable/ctonly_templates.d
+++ b/tests/compilable/ctonly_templates.d
@@ -1,0 +1,15 @@
+import std.algorithm.iteration;
+import std.array;
+
+int f(int x) @__ctfe
+{
+    return x + 1;
+}
+
+enum a = map!f([1, 2, 3]).array;
+
+import std.stdio;
+
+void main() {
+    writeln(a);
+}

--- a/tests/fail_compilation/ctonly_basic.d
+++ b/tests/fail_compilation/ctonly_basic.d
@@ -1,0 +1,24 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/ctonly_basic.d(23): Error: cannot call @__ctfe function `ctonly_basic.f` from non-@__ctfe function `D main`
+fail_compilation/ctonly_basic.d(23): Error: cannot call @__ctfe function `ctonly_basic.g!2.g` from non-@__ctfe function `D main`
+fail_compilation/ctonly_basic.d(23): Error: cannot take address of @__ctfe function `f`
+fail_compilation/ctonly_basic.d(23): Error: cannot take address of @__ctfe function `g`
+---
+*/
+
+int f(int x, int y) @__ctfe {
+    return x + y;
+}
+
+int g(int x)(int y) @__ctfe {
+    return x + y;
+}
+
+alias gf = g!2;
+
+import std.stdio;
+
+void main() {
+    writeln(f(2, 4), gf(0), &f, &gf);
+}

--- a/tests/fail_compilation/ctonly_basic.d
+++ b/tests/fail_compilation/ctonly_basic.d
@@ -1,14 +1,5 @@
 // RUN: not %ldc -c %s 2>&1 | FileCheck %s
 
-/* TEST_OUTPUT:
----
-fail_compilation/ctonly_basic.d(25): Error: cannot call @__ctfe function `ctonly_basic.f` from non-@__ctfe function `D main`
-fail_compilation/ctonly_basic.d(25): Error: cannot call @__ctfe function `ctonly_basic.g!2.g` from non-@__ctfe function `D main`
-fail_compilation/ctonly_basic.d(25): Error: cannot take address of @__ctfe function `f`
-fail_compilation/ctonly_basic.d(25): Error: cannot take address of @__ctfe function `g`
----
-*/
-
 int f(int x, int y) @__ctfe {
     return x + y;
 }
@@ -22,5 +13,9 @@ alias gf = g!2;
 import std.stdio;
 
 void main() {
+    // CHECK: ctonly_basic.d([[@LINE+4]]): Error: cannot call @__ctfe function `ctonly_basic.f` from non-@__ctfe function `D main`
+    // CHECK: ctonly_basic.d([[@LINE+3]]): Error: cannot call @__ctfe function `ctonly_basic.g!2.g` from non-@__ctfe function `D main`
+    // CHECK: ctonly_basic.d([[@LINE+2]]): Error: cannot take address of CTFE-only function `f`
+    // CHECK: ctonly_basic.d([[@LINE+1]]): Error: cannot take address of CTFE-only function `g`
     writeln(f(2, 4), gf(0), &f, &gf);
 }

--- a/tests/fail_compilation/ctonly_basic.d
+++ b/tests/fail_compilation/ctonly_basic.d
@@ -1,9 +1,11 @@
+// RUN: not %ldc -c %s 2>&1 | FileCheck %s
+
 /* TEST_OUTPUT:
 ---
-fail_compilation/ctonly_basic.d(23): Error: cannot call @__ctfe function `ctonly_basic.f` from non-@__ctfe function `D main`
-fail_compilation/ctonly_basic.d(23): Error: cannot call @__ctfe function `ctonly_basic.g!2.g` from non-@__ctfe function `D main`
-fail_compilation/ctonly_basic.d(23): Error: cannot take address of @__ctfe function `f`
-fail_compilation/ctonly_basic.d(23): Error: cannot take address of @__ctfe function `g`
+fail_compilation/ctonly_basic.d(25): Error: cannot call @__ctfe function `ctonly_basic.f` from non-@__ctfe function `D main`
+fail_compilation/ctonly_basic.d(25): Error: cannot call @__ctfe function `ctonly_basic.g!2.g` from non-@__ctfe function `D main`
+fail_compilation/ctonly_basic.d(25): Error: cannot take address of @__ctfe function `f`
+fail_compilation/ctonly_basic.d(25): Error: cannot take address of @__ctfe function `g`
 ---
 */
 

--- a/tests/fail_compilation/ctonly_class.d
+++ b/tests/fail_compilation/ctonly_class.d
@@ -1,12 +1,5 @@
 // RUN: not %ldc -c %s 2>&1 | FileCheck %s
 
-/* TEST_OUTPUT:
----
-fail_compilation/ctonly_class.d(26): Error: cannot call @__ctfe function `ctonly_class.C.f` from non-@__ctfe function `D main`
-fail_compilation/ctonly_class.d(27): Error: cannot call @__ctfe function `ctonly_class.C.g` from non-@__ctfe function `D main`
-fail_compilation/ctonly_class.d(29): Error: cannot call @__ctfe function `ctonly_class.CtOnly.this` from non-@__ctfe function `D main`
----
-*/
 class C {
     int v;
     this(int v_) { v = v_; }
@@ -23,8 +16,11 @@ class CtOnly {
 
 void main() {
     C i = new C(1);
+    // CHECK: ctonly_class.d([[@LINE+1]]): Error: cannot call @__ctfe function `ctonly_class.C.f` from non-@__ctfe function `D main`
     int a = i.f(3);
+    // CHECK: ctonly_class.d([[@LINE+1]]): Error: cannot call @__ctfe function `ctonly_class.C.g` from non-@__ctfe function `D main`
     int v = C.g(2);
 
+    // CHECK: ctonly_class.d([[@LINE+1]]): Error: cannot call @__ctfe function `ctonly_class.CtOnly.this` from non-@__ctfe function `D main`
     auto cl = new CtOnly(5);
 }

--- a/tests/fail_compilation/ctonly_class.d
+++ b/tests/fail_compilation/ctonly_class.d
@@ -1,8 +1,10 @@
+// RUN: not %ldc -c %s 2>&1 | FileCheck %s
+
 /* TEST_OUTPUT:
 ---
-fail_compilation/ctonly_class.d(24): Error: cannot call @__ctfe function `ctonly_class.C.f` from non-@__ctfe function `D main`
-fail_compilation/ctonly_class.d(25): Error: cannot call @__ctfe function `ctonly_class.C.g` from non-@__ctfe function `D main`
-fail_compilation/ctonly_class.d(27): Error: cannot call @__ctfe function `ctonly_class.CtOnly.this` from non-@__ctfe function `D main`
+fail_compilation/ctonly_class.d(26): Error: cannot call @__ctfe function `ctonly_class.C.f` from non-@__ctfe function `D main`
+fail_compilation/ctonly_class.d(27): Error: cannot call @__ctfe function `ctonly_class.C.g` from non-@__ctfe function `D main`
+fail_compilation/ctonly_class.d(29): Error: cannot call @__ctfe function `ctonly_class.CtOnly.this` from non-@__ctfe function `D main`
 ---
 */
 class C {

--- a/tests/fail_compilation/ctonly_class.d
+++ b/tests/fail_compilation/ctonly_class.d
@@ -1,0 +1,28 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/ctonly_class.d(24): Error: cannot call @__ctfe function `ctonly_class.C.f` from non-@__ctfe function `D main`
+fail_compilation/ctonly_class.d(25): Error: cannot call @__ctfe function `ctonly_class.C.g` from non-@__ctfe function `D main`
+fail_compilation/ctonly_class.d(27): Error: cannot call @__ctfe function `ctonly_class.CtOnly.this` from non-@__ctfe function `D main`
+---
+*/
+class C {
+    int v;
+    this(int v_) { v = v_; }
+    int f(int x) const @__ctfe { return x + v; }
+    static int g(int x) @__ctfe { return x + 2; }
+}
+
+class CtOnly {
+    int v;
+    this(int v_) @__ctfe { v = v_; }
+    int f(int x) const { return x + v; }
+    static int g(int x) { return x + 2; }
+}
+
+void main() {
+    C i = new C(1);
+    int a = i.f(3);
+    int v = C.g(2);
+
+    auto cl = new CtOnly(5);
+}

--- a/tests/fail_compilation/ctonly_nested.d
+++ b/tests/fail_compilation/ctonly_nested.d
@@ -1,0 +1,32 @@
+// RUN: not %ldc -c %s 2>&1 | FileCheck %s
+
+@__ctfe
+int foo() {
+    int bar() {
+        return 2;
+    }
+    // CHECK: ctonly_nested.d([[@LINE+1]]): Error: cannot take address of CTFE-only function `bar`
+    auto p = &bar; // this works because bar doesn't inherit the __ctfe attribute
+    return p() + 10;
+}
+
+int main() {
+    // CHECK: ctonly_nested.d([[@LINE+1]]): Error: cannot take address of CTFE-only function `foo`
+    auto p = &foo;
+    // CHECK: ctonly_nested.d([[@LINE+1]]): Error: cannot call @__ctfe function `ctonly_nested.foo` from non-@__ctfe function `D main`
+    int x = foo();
+    // CHECK: ctonly_nested.d([[@LINE+1]]): Error: cannot call @__ctfe function `ctonly_nested.bar` from non-@__ctfe function `D main`
+    int y = bar(x);
+    // CHECK: ctonly_nested.d([[@LINE+1]]): Error: cannot call @__ctfe function `ctonly_nested.baz` from non-@__ctfe function `D main`
+    int z = baz(y);
+    return x + y + z;
+}
+
+@__ctfe:
+int bar(int x) {
+    return x + 1;
+}
+
+int baz(int x) {
+    return x + 1;
+}

--- a/tests/fail_compilation/ctonly_templates.d
+++ b/tests/fail_compilation/ctonly_templates.d
@@ -1,7 +1,9 @@
+// RUN: not %ldc -c %s 2>&1 | FileCheck %s
+
 /* TEST_OUTPUT:
 ---
-fail_compilation/ctonly_templates.d(21): Error: cannot call @__ctfe function `std.array.array!(MapResult!(f, int[])).array` from non-@__ctfe function `D main`
-fail_compilation/ctonly_templates.d(21):        `std.array.array!(MapResult!(f, int[])).array` was inferred to be @__ctfe because it (transitively) calls `ctonly_templates.f`
+fail_compilation/ctonly_templates.d(23): Error: cannot call @__ctfe function `std.array.array!(MapResult!(f, int[])).array` from non-@__ctfe function `D main`
+fail_compilation/ctonly_templates.d(23):        `std.array.array!(MapResult!(f, int[])).array` was inferred to be @__ctfe because it (transitively) calls `ctonly_templates.f`
 ---
 */
 import std.algorithm.iteration;

--- a/tests/fail_compilation/ctonly_templates.d
+++ b/tests/fail_compilation/ctonly_templates.d
@@ -1,0 +1,22 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/ctonly_templates.d(21): Error: cannot call @__ctfe function `std.array.array!(MapResult!(f, int[])).array` from non-@__ctfe function `D main`
+fail_compilation/ctonly_templates.d(21):        `std.array.array!(MapResult!(f, int[])).array` was inferred to be @__ctfe because it (transitively) calls `ctonly_templates.f`
+---
+*/
+import std.algorithm.iteration;
+import std.array;
+
+int f(int x) @__ctfe
+{
+    return x + 1;
+}
+
+enum a = map!f([1, 2, 3]);
+
+import std.stdio;
+
+void main() {
+    // That fails, because `f` is called internally.
+    writeln(a.array);
+}

--- a/tests/fail_compilation/ctonly_templates.d
+++ b/tests/fail_compilation/ctonly_templates.d
@@ -1,11 +1,5 @@
 // RUN: not %ldc -c %s 2>&1 | FileCheck %s
 
-/* TEST_OUTPUT:
----
-fail_compilation/ctonly_templates.d(23): Error: cannot call @__ctfe function `std.array.array!(MapResult!(f, int[])).array` from non-@__ctfe function `D main`
-fail_compilation/ctonly_templates.d(23):        `std.array.array!(MapResult!(f, int[])).array` was inferred to be @__ctfe because it (transitively) calls `ctonly_templates.f`
----
-*/
 import std.algorithm.iteration;
 import std.array;
 
@@ -20,5 +14,6 @@ import std.stdio;
 
 void main() {
     // That fails, because `f` is called internally.
+    // CHECK: ctonly_templates.d([[@LINE+1]]): Error: cannot call @__ctfe function `std.array.array!(MapResult!(f, int[])).array` from non-@__ctfe function `D main`
     writeln(a.array);
 }


### PR DESCRIPTION
Support for `@__ctfe` attribute for marking CT-only functions, back ported to 1.30.