### PR TITLE
Cherry-pick #3 onto weka-1.38

### DIFF
--- a/.github/actions/5a-linux-arm64/action.yml
+++ b/.github/actions/5a-linux-arm64/action.yml
@@ -1,0 +1,53 @@
+name: "Linux: Cross-compile ARM64 libraries & copy to install dir"
+runs:
+  using: composite
+  steps:
+
+    - name: Install Cross-Compile Support (ARM64)
+      uses: cyberjunk/gha-ubuntu-cross@v5
+      with:
+        arch: arm64
+
+          #    - name: Install libx11-dev for ARM64
+          #run: sudo apt-get install libx11-dev:arm64
+
+    - shell: bash
+      run: |
+        set -eux
+        cd ..
+
+        # keep using our own lld as a linker
+        sudo rm /usr/bin/aarch64-linux-gnu-ld
+        sudo ln -sf /usr/bin/ld /usr
+
+        arch='aarch64'
+        triple="$arch-linux-gnu"
+
+        export CC=clang
+        ./installed/bin/ldc-build-runtime --ninja \
+          --buildDir="build-libs-$arch" \
+          --dFlags="-mtriple=$triple -gcc=clang" \
+          --cFlags="--target=$triple" \
+          --linkerFlags="--target=$triple" \
+          --ldcSrcDir="$PWD/ldc"
+
+        mkdir "installed/lib-$arch"
+        cp -rv "build-libs-$arch"/lib/* "installed/lib-$arch/"
+
+        section="
+        \"($arch|arm64).*-linux-gnu\":
+        {
+            switches = [
+                \"-defaultlib=phobos2-ldc,druntime-ldc\",
+                \"--mcpu=neoverse-n1\",
+                \"-mattr=+crc\",
+                \"-gcc=$arch-linux-gnu-gcc\",
+                \"-linker=gold\",
+            ];
+            lib-dirs = [
+                \"%%ldcbinarypath%%/../lib-$arch\",
+            ];
+            rpath = \"%%ldcbinarypath%%/../lib-$arch\";
+        };"
+        echo "$section" >> installed/etc/ldc2.conf
+        cat installed/etc/ldc2.conf

--- a/.github/actions/merge-macos/action.yml
+++ b/.github/actions/merge-macos/action.yml
@@ -10,27 +10,37 @@ runs:
         path: artifacts/
         merge-multiple: true # place all files into artifacts/ directly
 
+    - name: Download Linux x86_64 artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: linux-x86_64
+        path: artifacts/
+
     - name: Extract & merge artifacts
       shell: bash
       run: |
         set -euxo pipefail
 
-        mkdir ldc2-{x86_64,arm64}
-        tar -xf artifacts/ldc2-*-x86_64.tar.xz --strip 1 -C ldc2-x86_64
-        tar -xf artifacts/ldc2-*-arm64.tar.xz  --strip 1 -C ldc2-arm64
+        mkdir ldc2-osx-{x86_64,arm64}
+        mkdir ldc2-linux-x86_64
+        tar -xf artifacts/ldc2-*-osx-x86_64.tar.xz --strip 1 -C ldc2-osx-x86_64
+        tar -xf artifacts/ldc2-*-osx-arm64.tar.xz  --strip 1 -C ldc2-osx-arm64
+        tar -xf artifacts/ldc2-*-linux-x86_64.tar.xz --strip 1 -C ldc2-linux-x86_64
 
-        cp -R ldc2-x86_64 ldc2-universal
+        cp -R ldc2-osx-x86_64 ldc2-universal
         cd ldc2-universal
 
         # rename/copy lib dirs
         mv lib                            lib-x86_64
-        cp -R ../ldc2-arm64/lib           lib-arm64
+        cp -R ../ldc2-osx-arm64/lib       lib-arm64
         # cp -R ../ldc2-arm64/lib-ios-arm64 ./
+        cp -R ../ldc2-linux-x86_64/lib          lib-linux-x86_64
+        cp -R ../ldc2-linux-x86_64/lib-aarch64  lib-linux-arm64
 
         # merge executables to universal ones
         for exe in bin/*; do
           rm $exe
-          lipo -create -output $exe ../ldc2-x86_64/$exe ../ldc2-arm64/$exe
+          lipo -create -output $exe ../ldc2-osx-x86_64/$exe ../ldc2-osx-arm64/$exe
         done
 
         # ldc2.conf: replace the default section and add extra sections
@@ -79,6 +89,34 @@ runs:
                 \"%%ldcbinarypath%%/../lib-ios-arm64\",
             ];
             rpath = \"%%ldcbinarypath%%/../lib-ios-arm64\";
+        };
+
+        \"(aarch64\\|arm64).\\*-linux-gnu\":
+        {
+            switches = [
+                \"-defaultlib=phobos2-ldc,druntime-ldc\",
+                \"--mcpu=neoverse-n1\",
+                \"-mattr=+crc\",
+                \"-gcc=aarch64-linux-gnu-gcc\",
+                \"-linker=gold\",
+            ];
+            lib-dirs = [
+                \"%%ldcbinarypath%%/../lib-linux-arm64\",
+            ];
+            rpath = \"%%ldcbinarypath%%/../lib-linux-arm64\";
+        };
+
+        \"(x86_64\\|amd64).\\*-linux-gnu\":
+        {
+            switches = [
+                \"-defaultlib=phobos2-ldc,druntime-ldc\",
+                \"-gcc=x86_64-linux-gnu-gcc\",
+                \"-linker=gold\",
+            ];
+            lib-dirs = [
+                \"%%ldcbinarypath%%/../lib-linux-x86_64\",
+            ];
+            rpath = \"%%ldcbinarypath%%/../lib-linux-x86_64\";
         };"
 
         perl -0777 -pi -e "s|\\ndefault:\\n.+?\\n\\};|$sections|s" etc/ldc2.conf

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -115,6 +115,9 @@ jobs:
 #        with:
 #          arch: ${{ matrix.arch }}
 
+      - name: "Linux: Cross-compile ARM64 libraries, copy to install dir & extend ldc2.conf"
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/5a-linux-arm64
       - name: Run a few integration tests against the installed compiler
         uses: ./.github/actions/6-integration-test
 #      - name: 'macOS: Run iOS cross-compilation integration test'


### PR DESCRIPTION
Pack arm64 libs into linux package + x86_64/arm64 linux libs into OSX package (#3)

* gha/linux: cross-compile ARM64 libs & package them

* gha: pack linux libs into macos universal package

And add corresponding config sections.

This enables prebuilt OS X compiler to be useful for local agent build.