### PR TITLE
Add an cmdline option to just run hdrgen

### DIFF
--- a/dmd/globals.d
+++ b/dmd/globals.d
@@ -257,6 +257,7 @@ extern (C++) struct Param
     Array!(const(char)*) ddocfiles;     // macro include files for Ddoc
 
     bool doHdrGeneration;               // process embedded documentation comments
+    bool doHdrGenerationOnly;           // generate 'header' file and exit
     const(char)[] hdrdir;                // write 'header' file to docdir directory
     const(char)[] hdrname;               // write 'header' file to docname
     bool hdrStripPlainFunctions = true; // strip the bodies of plain (non-template) functions

--- a/dmd/globals.h
+++ b/dmd/globals.h
@@ -219,6 +219,7 @@ struct Param
     Array<const char *> ddocfiles;  // macro include files for Ddoc
 
     bool doHdrGeneration;  // process embedded documentation comments
+    bool doHdrGenerationOnly; // generate 'header' file and exit
     DString hdrdir;        // write 'header' file to docdir directory
     DString hdrname;       // write 'header' file to docname
     bool hdrStripPlainFunctions; // strip the bodies of plain (non-template) functions

--- a/dmd/mars.d
+++ b/dmd/mars.d
@@ -516,6 +516,8 @@ version (IN_LLVM)
     if (global.errors)
         removeHdrFilesAndFail(params, modules);
 
+    if (params.doHdrGenerationOnly) return 0;
+
     // load all unconditional imports for better symbol resolving
     foreach (m; modules)
     {

--- a/driver/cl_options.cpp
+++ b/driver/cl_options.cpp
@@ -293,6 +293,10 @@ cl::opt<bool>
     hdrKeepAllBodies("Hkeep-all-bodies", cl::ZeroOrMore,
                      cl::desc("Keep all function bodies in .di files"));
 
+static cl::opt<bool, true>
+    doHdrGenOnly("Honly", cl::desc("Generate 'header' file and exit"), cl::ZeroOrMore,
+            cl::location(global.params.doHdrGenerationOnly));
+
 // C++ header generation options
 
 // `-HC[=silent|verbose]` parser. Required for defaulting to `silent`.

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -355,7 +355,8 @@ void parseCommandLine(Strings &sourceFiles) {
   global.params.hdrdir = opts::fromPathString(hdrDir);
   global.params.hdrname = opts::fromPathString(hdrFile);
   global.params.doHdrGeneration |=
-      global.params.hdrdir.length || global.params.hdrname.length;
+      global.params.hdrdir.length || global.params.hdrname.length ||
+      global.params.doHdrGenerationOnly;
 
   global.params.cxxhdrdir = opts::fromPathString(cxxHdrDir);
   global.params.cxxhdrname = opts::fromPathString(cxxHdrFile);


### PR DESCRIPTION
Adds a new `-Honly` cmdline argument that acts like `-H` but cause the compiler to exit after headers are generated. This is useful in my bazel work.