### PR TITLE
caller-attr: Option A @CTX_SWITCH caller-required attribute (postfix marker, foreach/opApply, mangling)

### DIFF
--- a/dmd/attrib.d
+++ b/dmd/attrib.d
@@ -31,8 +31,10 @@ import dmd.cond;
 import dmd.declaration;
 import dmd.dmodule;
 import dmd.dscope;
+import dmd.dstruct;
 import dmd.dsymbol;
 import dmd.dsymbolsem;
+import dmd.dtemplate;
 import dmd.errors;
 import dmd.expression;
 import dmd.expressionsem;
@@ -1340,4 +1342,48 @@ bool isEnumAttribute(Expression e, Identifier id)
         return true;
 
     return false;
+}
+
+/**
+ * Option A — caller-required attributes.
+ *
+ * Detects a `callerAttr!("NAME", fake)` instantiation, i.e. an instance of the
+ * `callerAttr` struct template from `core.attribute`. On success fills `name`
+ * (the attribute's string name) and `fake` (true for the `callerAttrFake`
+ * migration variant).
+ *
+ * Returns: true if `sd` is such an instantiation.
+ */
+bool isCallerAttrStruct(StructDeclaration sd, out const(char)[] name, out bool fake)
+{
+    if (!sd || !sd.parent)
+        return false;
+    auto ti = sd.parent.isTemplateInstance();
+    if (!ti || !ti.tempdecl)
+        return false;
+    if (!isCoreUda(ti.tempdecl, Id.udaCallerAttr))
+        return false;
+
+    // Read the resolved template value arguments: (string name, bool fake = false).
+    if (ti.tdtypes.length >= 1)
+        if (auto e = ti.tdtypes[0].isExpression())
+            if (auto se = e.isStringExp())
+                name = se.peekString();
+    fake = false;
+    if (ti.tdtypes.length >= 2)
+        if (auto e = ti.tdtypes[1].isExpression())
+            fake = e.toInteger() != 0;
+    return name !is null;
+}
+
+/// As `isCallerAttrStruct`, but starting from a UDA expression (a `TypeExp` of the struct).
+bool isCallerAttrExp(Expression e, out const(char)[] name, out bool fake)
+{
+    auto te = e.isTypeExp();
+    if (!te)
+        return false;
+    auto ts = te.type.isTypeStruct();
+    if (!ts)
+        return false;
+    return isCallerAttrStruct(ts.sym, name, fake);
 }

--- a/dmd/dmangle.d
+++ b/dmd/dmangle.d
@@ -137,6 +137,7 @@ import core.stdc.string;
 import dmd.aggregate;
 import dmd.arraytypes;
 import dmd.astenums;
+import dmd.attrib : isCallerAttrExp;
 import dmd.basicmangle;
 import dmd.dclass;
 import dmd.declaration;
@@ -406,6 +407,109 @@ void mangleFuncType(TypeFunction t, TypeFunction ta, ubyte modMask, Type tret, r
 
 /*************************************************************
  */
+/****************************************************************
+ * Option A — caller-required attributes participate in name mangling, but ONLY
+ * where they must to break an otherwise-identical symbol collision.
+ *
+ * A `@(callerAttr!"NAME")` (or its `callerAttrFake` variant) is an ordinary UDA,
+ * invisible to the mangler. When two overloads differ ONLY by the attribute —
+ * e.g. `RobinHashTable`'s plain vs `@CTX_SWITCH` `opApply` — they mangle to the
+ * same symbol and codegen silently drops one ("skipping definition ... same
+ * mangled name"). To fix that we append a discriminator to the attribute-bearing
+ * overload's symbol.
+ *
+ * Critically, the discriminator is emitted ONLY when `fd` has a same-name,
+ * same-type overload sibling (the real collision). A standalone caller-attr
+ * function (`yield`, `submitTask`, a socket `send`/`recv`, ...) keeps its
+ * baseline mangle, so its definition and every cross-module call site agree —
+ * otherwise the discriminator would be applied inconsistently across separately
+ * compiled modules (it depends on whether the UDA happens to be semantically
+ * resolved when the symbol is first mangled and cached), producing `undefined
+ * symbol` link errors. Gating on collision also makes the result independent of
+ * that resolution timing for non-overloaded functions: with no sibling we emit
+ * nothing regardless. The colliding `opApply` overloads are co-resolved members
+ * of the same struct template, so their treatment is consistent everywhere.
+ */
+void mangleCallerAttrDisc(Dsymbol sym, ref OutBuffer buf)
+{
+    auto fd = sym ? sym.isFuncDeclaration() : null;
+    if (!fd || !fd.userAttribDecl || !fd.type)
+        return;
+    auto udas = fd.userAttribDecl.getAttributes();
+    if (!udas)
+        return;
+
+    // Does `fd` carry any caller-attr UDA at all?
+    bool hasAttr;
+    foreach (uda; (*udas)[])
+    {
+        const(char)[] n;
+        bool f;
+        if (auto tup = uda.isTupleExp())
+        {
+            foreach (e; (*tup.exps)[])
+                if (e && isCallerAttrExp(e, n, f)) { hasAttr = true; break; }
+        }
+        else if (uda && isCallerAttrExp(uda, n, f))
+            hasAttr = true;
+        if (hasAttr)
+            break;
+    }
+    if (!hasAttr)
+        return;
+
+    // Gate: only disambiguate when a same-name/same-type overload sibling exists.
+    // Enumerate the WHOLE overload set from its head — `overnext` is singly
+    // linked, so starting from `fd` alone could miss earlier-declared siblings
+    // (the `@CTX_SWITCH` overload is typically declared after the plain one).
+    Dsymbol head = fd;
+    if (auto p = fd.parent)
+        if (auto sds = p.isScopeDsymbol())
+            if (sds.symtab)
+                if (auto s = sds.symtab.lookup(fd.ident))
+                    head = s;
+
+    bool collides;
+    overloadApply(head, (Dsymbol s) {
+        auto f = s.isFuncDeclaration();
+        if (f && f !is fd && f.type && f.type.equals(fd.type))
+        {
+            collides = true;
+            return 1;
+        }
+        return 0;
+    });
+    if (!collides)
+        return;
+
+    // Emit: 'Y' <'F' fake | 'R' real> <len> <name> per caller-attr.
+    void emit(Expression e)
+    {
+        if (!e)
+            return;
+        const(char)[] name;
+        bool fake;
+        if (isCallerAttrExp(e, name, fake))
+        {
+            buf.writeByte('Y');
+            buf.writeByte(fake ? 'F' : 'R');
+            buf.print(cast(int) name.length);
+            buf.writestring(name);
+        }
+    }
+
+    foreach (uda; (*udas)[])
+    {
+        if (auto tup = uda.isTupleExp())
+        {
+            foreach (e; (*tup.exps)[])
+                emit(e);
+        }
+        else
+            emit(uda);
+    }
+}
+
 void mangleParameter(Parameter p, ref OutBuffer buf, ref Backref backref)
 {
     // https://dlang.org/spec/abi.html#Parameter
@@ -572,6 +676,8 @@ public:
         //printf("fd.type = %s\n", fd.type.toChars());
         if (fd.needThis() || fd.isNested())
             buf.writeByte('M');
+
+        mangleCallerAttrDisc(fd, *buf);
 
         if (!fd.type || fd.type.ty == Terror)
         {

--- a/dmd/expression.d
+++ b/dmd/expression.d
@@ -3553,6 +3553,7 @@ extern (C++) final class CallExp : UnaExp
     bool ignoreAttributes;  /// don't enforce attributes (e.g. call @gc function in @nogc code)
     bool isUfcsRewrite;     /// the first argument was pushed in here by a UFCS rewrite
     VarDeclaration vthis2;  // container for multi-context
+    Identifier markedCallerAttr; /// Option A: alias name of the `.ATTR` caller-attr marker written at this call site (null if none)
 
     /// Puts the `arguments` and `names` into an `ArgumentList` for easily passing them around.
     /// The fields are still separate for backwards compatibility

--- a/dmd/expression.d
+++ b/dmd/expression.d
@@ -3554,6 +3554,7 @@ extern (C++) final class CallExp : UnaExp
     bool isUfcsRewrite;     /// the first argument was pushed in here by a UFCS rewrite
     VarDeclaration vthis2;  // container for multi-context
     Identifier markedCallerAttr; /// Option A: alias name of the `.ATTR` caller-attr marker written at this call site (null if none)
+    bool callerAttrAutoMarked;   /// Option A: compiler-generated call (e.g. a `foreach`->`opApply` lowering) that is treated as implicitly marked — skips the "must be marked" requirement (E2) but still propagates the caller-attr to the enclosing function (E1)
 
     /// Puts the `arguments` and `names` into an `ArgumentList` for easily passing them around.
     /// The fields are still separate for backwards compatibility
@@ -3630,7 +3631,12 @@ extern (C++) final class CallExp : UnaExp
 
     override CallExp syntaxCopy()
     {
-        return new CallExp(loc, e1.syntaxCopy(), arraySyntaxCopy(arguments), names ? names.copy() : null);
+        auto ce = new CallExp(loc, e1.syntaxCopy(), arraySyntaxCopy(arguments), names ? names.copy() : null);
+        // Option A: the caller-attr call-site marker is set at parse time, so it must
+        // survive syntaxCopy() — otherwise template instantiations lose the marker and
+        // wrongly report "call must be marked". (Identifiers are interned; copy the ref.)
+        ce.markedCallerAttr = markedCallerAttr;
+        return ce;
     }
 
     override bool isLvalue()

--- a/dmd/expressionsem.d
+++ b/dmd/expressionsem.d
@@ -1094,6 +1094,20 @@ private Expression resolveUFCS(Scope* sc, CallExp ce)
     {
         Identifier ident = die.ident;
 
+        // Option A: caller-required attribute call-site marker `callee.ATTR(args)`.
+        // If `ident` names a `callerAttr` alias visible in this scope, the member
+        // access is a marker: record it and rewrite to a plain call `callee(args)`.
+        {
+            const(char)[] caName;
+            bool caFake;
+            if (callerAttrMarkerName(sc, die.loc, ident, caName, caFake))
+            {
+                ce.markedCallerAttr = Identifier.idPool(caName);
+                ce.e1 = die.e1;
+                return null;
+            }
+        }
+
         Expression ex = die.dotIdSemanticPropX(sc);
         if (ex != die)
         {
@@ -6625,6 +6639,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 exp.f.checkPurity(exp.loc, sc);
                 exp.f.checkSafety(exp.loc, sc);
                 exp.f.checkNogc(exp.loc, sc);
+                checkCallerAttr(exp, sc, exp.f);
                 if (exp.f.checkNestedReference(sc, exp.loc))
                     return setError();
             }
@@ -6653,6 +6668,12 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 if (err)
                     return setError();
             }
+
+            // Option A: caller-attr enforcement for indirect (delegate / function-pointer)
+            // calls. The attribute is carried by the callee variable's declaration, e.g.
+            // a `@CTX_SWITCH void delegate()` parameter.
+            if (!exp.f)
+                checkCallerAttr(exp, sc, callerAttrCalleeVar(exp.e1));
 
             if (t1.ty == Tpointer)
             {
@@ -6763,6 +6784,10 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             exp.arguments = new Expressions();
         if (functionParameters(exp.loc, sc, cast(TypeFunction)t1, ethis, tthis, exp.argumentList, exp.f, &exp.type, &argprefix))
             return setError();
+
+        // Option A: a context-switching callable (e.g. a lambda that infers @CTX_SWITCH)
+        // may only be passed to a parameter that itself carries that caller-attribute.
+        checkCallerAttrArgs(exp, sc, cast(TypeFunction)t1);
 
         if (!exp.type)
         {
@@ -8113,6 +8138,20 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         {
             printf("DotIdExp::semantic(this = %p, '%s')\n", exp, exp.toChars());
             //printf("e1.op = %d, '%s'\n", e1.op, Token.toChars(e1.op));
+        }
+
+        // Option A: no-parens caller-attr marker `callee.ATTR;` is a marked zero-arg call.
+        if (!(sc.flags & SCOPE.Cfile))
+        {
+            const(char)[] caName;
+            bool caFake;
+            if (callerAttrMarkerName(sc, exp.loc, exp.ident, caName, caFake))
+            {
+                auto ce = new CallExp(exp.loc, exp.e1);
+                ce.markedCallerAttr = Identifier.idPool(caName);
+                result = ce.expressionSemantic(sc);
+                return;
+            }
         }
 
         if (sc.flags & SCOPE.Cfile)
@@ -16276,6 +16315,245 @@ bool checkAddressable(Expression e, Scope* sc)
  *  f   = function to be checked
  * Returns: `true` if error occur.
  */
+/******************************************
+ * Option A — caller-required attributes (e.g. `@CTX_SWITCH`).
+ *
+ * Returns true (filling `name`/`fake`) if `ident`, resolved in `sc`, names a
+ * `callerAttr` alias — i.e. a `.ATTR` call-site marker.
+ */
+private bool callerAttrMarkerName(Scope* sc, Loc loc, Identifier ident, out const(char)[] name, out bool fake)
+{
+    if (!ident)
+        return false;
+    Dsymbol pscopesym;
+    Dsymbol s = sc.search(loc, ident, pscopesym);
+    if (!s)
+        return false;
+    s = s.toAlias();
+    if (auto t = s.getType())
+        if (auto ts = t.isTypeStruct())
+            return isCallerAttrStruct(ts.sym, name, fake);
+    if (auto sd = s.isStructDeclaration())
+        return isCallerAttrStruct(sd, name, fake);
+    return false;
+}
+
+/// Returns true if function `fd` carries the caller-attribute `wantName` with the given `wantFake` flag.
+private bool symCarriesCallerAttr(Dsymbol sym, Scope* sc, const(char)[] wantName, bool wantFake)
+{
+    if (!sym)
+        return false;
+    bool found;
+    foreachUda(sym, sc, (Expression e) {
+        const(char)[] n;
+        bool f;
+        if (isCallerAttrExp(e, n, f) && f == wantFake && n == wantName)
+        {
+            found = true;
+            return 1;
+        }
+        return 0;
+    });
+    return found;
+}
+
+/// Returns the UDA-carrying variable behind a callee expression, for indirect
+/// (delegate / function-pointer) calls — e.g. the parameter `dg` in `dg.ATTR()`.
+private VarDeclaration callerAttrCalleeVar(Expression e1)
+{
+    if (auto ve = e1.isVarExp())
+        return ve.var ? ve.var.isVarDeclaration() : null;
+    if (auto dve = e1.isDotVarExp())
+        return dve.var ? dve.var.isVarDeclaration() : null;
+    return null;
+}
+
+/******************************************
+ * Option A enforcement, run per call. `callee` is the UDA-carrying symbol of the
+ * thing being called: a `FuncDeclaration` for a direct call, or the delegate /
+ * function-pointer `VarDeclaration` for an indirect call (may be null when the
+ * callee carries no usable symbol, e.g. a function literal).
+ *
+ *  - the `.ATTR` marker must match the callee's actual caller-attributes (E2/E3),
+ *  - a caller-required attribute propagates upward: the enclosing function must
+ *    itself carry it (E1), unless the callee is a `callerAttrFake` migration shim.
+ */
+private void checkCallerAttr(CallExp ce, Scope* sc, Dsymbol callee)
+{
+    if (ce.ignoreAttributes)
+        return;
+
+    const(char)[] markName = ce.markedCallerAttr ? ce.markedCallerAttr.toString() : null;
+    bool markerMatched = false;
+
+    if (callee)
+    foreachUda(callee, sc, (Expression e) {
+        const(char)[] name;
+        bool fake;
+        if (!isCallerAttrExp(e, name, fake))
+            return 0;
+
+        if (markName !is null && markName == name)
+            markerMatched = true;
+
+        if (fake)
+            return 0; // fake shim: no marker requirement, no propagation
+
+        // E2: a `@name` call must carry the `.name` marker.
+        if (markName is null || markName != name)
+        {
+            error(ce.loc, "call to `@%.*s` function `%s` must be marked `%s.%.*s(...)`",
+                cast(int) name.length, name.ptr, callee.toPrettyChars(),
+                ce.e1.toChars(), cast(int) name.length, name.ptr);
+            return 0;
+        }
+
+        // E1: upward propagation — the enclosing function must itself carry `name`
+        // (real or fake). Exception: a lambda (function literal) infers the
+        // attribute from its body instead of erroring, just like `@nogc`/`@safe`,
+        // so an in-place lambda may perform a marked context-switch call.
+        if (sc.func &&
+            !symCarriesCallerAttr(sc.func, sc, name, false) &&
+            !symCarriesCallerAttr(sc.func, sc, name, true))
+        {
+            if (sc.func.isFuncLiteralDeclaration())
+                recordInferredCallerAttr(sc.func, name); // lambda infers `@name`
+            else
+                error(ce.loc, "non-`@%.*s` %s `%s` cannot call `@%.*s` function `%s`",
+                    cast(int) name.length, name.ptr, sc.func.kind(), sc.func.toPrettyChars(),
+                    cast(int) name.length, name.ptr, callee.toPrettyChars());
+        }
+        return 0;
+    });
+
+    // E3: a `.name` marker was written, but the callee carries no such attribute.
+    if (markName !is null && !markerMatched)
+    {
+        const(char)* who = callee ? callee.toPrettyChars() : ce.e1.toChars();
+        error(ce.loc, "`%s` is not a `@%.*s` function; remove the `.%.*s` marker",
+            who, cast(int) markName.length, markName.ptr,
+            cast(int) markName.length, markName.ptr);
+    }
+}
+
+// Side table of caller-attributes inferred on function literals (lambdas), keyed by
+// the literal's declaration. Avoids adding a field to the C++-mirrored FuncDeclaration.
+private __gshared const(char)[][][void*] inferredCallerAttrsByFunc;
+
+private void recordInferredCallerAttr(FuncDeclaration fd, const(char)[] name)
+{
+    auto key = cast(void*) fd;
+    if (auto existing = key in inferredCallerAttrsByFunc)
+    {
+        foreach (n; *existing)
+            if (n == name)
+                return;
+        *existing ~= name;
+    }
+    else
+        inferredCallerAttrsByFunc[key] = [name];
+}
+
+/// Does `fd` carry caller-attribute `name` — either explicitly (UDA) or inferred (lambda)?
+private bool funcHasCallerAttr(FuncDeclaration fd, Scope* sc, const(char)[] name)
+{
+    if (!fd)
+        return false;
+    if (symCarriesCallerAttr(fd, sc, name, false) || symCarriesCallerAttr(fd, sc, name, true))
+        return true;
+    if (auto existing = cast(void*) fd in inferredCallerAttrsByFunc)
+        foreach (n; *existing)
+            if (n == name)
+                return true;
+    return false;
+}
+
+/// Returns the callable behind an argument expression, if it is a function/delegate
+/// literal or a reference to a function (`&fn`).
+private FuncDeclaration argCallable(Expression a)
+{
+    if (auto ce2 = a.isCommaExp())
+        a = ce2.e2;
+    if (auto fe = a.isFuncExp())
+        return fe.fd;
+    if (auto de = a.isDelegateExp())
+        return de.func;
+    if (auto soe = a.isSymOffExp())
+        return soe.var ? soe.var.isFuncDeclaration() : null;
+    if (auto ve = a.isVarExp())
+        return ve.var ? ve.var.isFuncDeclaration() : null;
+    return null;
+}
+
+/// True if parameter `p` carries caller-attribute `name` (real or fake).
+private bool paramCarriesCallerAttr(Parameter p, Scope* sc, const(char)[] name)
+{
+    if (!p || !p.userAttribDecl)
+        return false;
+    bool found;
+    auto udas = p.userAttribDecl.getAttributes();
+    arrayExpressionSemantic(udas.peekSlice(), sc, true);
+    foreach (uda; *udas)
+    {
+        auto tup = uda.isTupleExp();
+        if (!tup)
+            continue;
+        foreach (e; *tup.exps)
+        {
+            const(char)[] n;
+            bool f;
+            if (isCallerAttrExp(e, n, f) && n == name)
+                found = true;
+        }
+    }
+    return found;
+}
+
+/******************************************
+ * Option A value-side check: a context-switching callable argument (e.g. a lambda
+ * that infers `@CTX_SWITCH`, or a function carrying it) may only be passed to a
+ * parameter that itself carries that caller-attribute. Otherwise the capability
+ * would leak into a context that never acknowledged it.
+ */
+private void checkCallerAttrArgs(CallExp ce, Scope* sc, TypeFunction tf)
+{
+    if (ce.ignoreAttributes || !tf || !ce.arguments)
+        return;
+    const size_t nparams = tf.parameterList.length;
+    foreach (i, arg; (*ce.arguments)[])
+    {
+        if (i >= nparams)
+            break;
+        auto callee = argCallable(arg);
+        if (!callee)
+            continue;
+        Parameter p = tf.parameterList[i];
+        // For every caller-attribute the argument carries (explicit or inferred),
+        // the parameter must carry it too.
+        const(char)* calleeDesc = callee.isFuncLiteralDeclaration() ? "lambda" : callee.toPrettyChars();
+        void checkName(const(char)[] name)
+        {
+            if (name.length && !paramCarriesCallerAttr(p, sc, name))
+                error(ce.loc, "cannot pass `@%.*s` %s to non-`@%.*s` parameter `%s`",
+                    cast(int) name.length, name.ptr, calleeDesc,
+                    cast(int) name.length, name.ptr,
+                    p.ident ? p.ident.toChars() : arg.toChars());
+        }
+        // explicit UDAs on the callee
+        foreachUda(callee, sc, (Expression e) {
+            const(char)[] n;
+            bool f;
+            if (isCallerAttrExp(e, n, f) && !f)
+                checkName(n);
+            return 0;
+        });
+        // inferred (lambda) caller-attrs
+        if (auto existing = cast(void*) callee in inferredCallerAttrsByFunc)
+            foreach (n; *existing)
+                checkName(n);
+    }
+}
+
 private bool checkFunctionAttributes(Expression exp, Scope* sc, FuncDeclaration f)
 {
     bool error = f.checkDisabled(exp.loc, sc);
@@ -16283,6 +16561,8 @@ private bool checkFunctionAttributes(Expression exp, Scope* sc, FuncDeclaration 
     error |= f.checkPurity(exp.loc, sc);
     error |= f.checkSafety(exp.loc, sc);
     error |= f.checkNogc(exp.loc, sc);
+    if (auto ce = exp.isCallExp())
+        checkCallerAttr(ce, sc, f);
     return error;
 }
 

--- a/dmd/expressionsem.d
+++ b/dmd/expressionsem.d
@@ -1094,20 +1094,6 @@ private Expression resolveUFCS(Scope* sc, CallExp ce)
     {
         Identifier ident = die.ident;
 
-        // Option A: caller-required attribute call-site marker `callee.ATTR(args)`.
-        // If `ident` names a `callerAttr` alias visible in this scope, the member
-        // access is a marker: record it and rewrite to a plain call `callee(args)`.
-        {
-            const(char)[] caName;
-            bool caFake;
-            if (callerAttrMarkerName(sc, die.loc, ident, caName, caFake))
-            {
-                ce.markedCallerAttr = Identifier.idPool(caName);
-                ce.e1 = die.e1;
-                return null;
-            }
-        }
-
         Expression ex = die.dotIdSemanticPropX(sc);
         if (ex != die)
         {
@@ -8138,20 +8124,6 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         {
             printf("DotIdExp::semantic(this = %p, '%s')\n", exp, exp.toChars());
             //printf("e1.op = %d, '%s'\n", e1.op, Token.toChars(e1.op));
-        }
-
-        // Option A: no-parens caller-attr marker `callee.ATTR;` is a marked zero-arg call.
-        if (!(sc.flags & SCOPE.Cfile))
-        {
-            const(char)[] caName;
-            bool caFake;
-            if (callerAttrMarkerName(sc, exp.loc, exp.ident, caName, caFake))
-            {
-                auto ce = new CallExp(exp.loc, exp.e1);
-                ce.markedCallerAttr = Identifier.idPool(caName);
-                result = ce.expressionSemantic(sc);
-                return;
-            }
         }
 
         if (sc.flags & SCOPE.Cfile)
@@ -16383,7 +16355,19 @@ private void checkCallerAttr(CallExp ce, Scope* sc, Dsymbol callee)
     if (ce.ignoreAttributes)
         return;
 
-    const(char)[] markName = ce.markedCallerAttr ? ce.markedCallerAttr.toString() : null;
+    // The parser records the raw marker identifier (`@CTX_SWITCH`); resolve it through
+    // its `callerAttr` alias to the actual attribute name.
+    const(char)[] markName = null;
+    if (ce.markedCallerAttr)
+    {
+        bool mfake;
+        if (!callerAttrMarkerName(sc, ce.loc, ce.markedCallerAttr, markName, mfake))
+        {
+            error(ce.loc, "`@%s` is not a caller-required attribute (declare it with `callerAttr`)",
+                ce.markedCallerAttr.toChars());
+            return;
+        }
+    }
     bool markerMatched = false;
 
     if (callee)
@@ -16399,10 +16383,10 @@ private void checkCallerAttr(CallExp ce, Scope* sc, Dsymbol callee)
         if (fake)
             return 0; // fake shim: no marker requirement, no propagation
 
-        // E2: a `@name` call must carry the `.name` marker.
+        // E2: a `@name` call must carry the `() @name` marker.
         if (markName is null || markName != name)
         {
-            error(ce.loc, "call to `@%.*s` function `%s` must be marked `%s.%.*s(...)`",
+            error(ce.loc, "call to `@%.*s` function `%s` must be marked `%s() @%.*s`",
                 cast(int) name.length, name.ptr, callee.toPrettyChars(),
                 ce.e1.toChars(), cast(int) name.length, name.ptr);
             return 0;
@@ -16430,7 +16414,7 @@ private void checkCallerAttr(CallExp ce, Scope* sc, Dsymbol callee)
     if (markName !is null && !markerMatched)
     {
         const(char)* who = callee ? callee.toPrettyChars() : ce.e1.toChars();
-        error(ce.loc, "`%s` is not a `@%.*s` function; remove the `.%.*s` marker",
+        error(ce.loc, "`%s` is not a `@%.*s` function; remove the `@%.*s` marker",
             who, cast(int) markName.length, markName.ptr,
             cast(int) markName.length, markName.ptr);
     }

--- a/dmd/expressionsem.d
+++ b/dmd/expressionsem.d
@@ -16383,8 +16383,10 @@ private void checkCallerAttr(CallExp ce, Scope* sc, Dsymbol callee)
         if (fake)
             return 0; // fake shim: no marker requirement, no propagation
 
-        // E2: a `@name` call must carry the `() @name` marker.
-        if (markName is null || markName != name)
+        // E2: a `@name` call must carry the `() @name` marker — unless this is a compiler-generated
+        // call that is implicitly marked (e.g. a `foreach`->`opApply` lowering), where there is no
+        // place for a user marker; such calls still propagate via E1 below.
+        if ((markName is null || markName != name) && !ce.callerAttrAutoMarked)
         {
             error(ce.loc, "call to `@%.*s` function `%s` must be marked `%s() @%.*s`",
                 cast(int) name.length, name.ptr, callee.toPrettyChars(),
@@ -16401,11 +16403,37 @@ private void checkCallerAttr(CallExp ce, Scope* sc, Dsymbol callee)
             !symCarriesCallerAttr(sc.func, sc, name, true))
         {
             if (sc.func.isFuncLiteralDeclaration())
+            {
                 recordInferredCallerAttr(sc.func, name); // lambda infers `@name`
+                // Remember where the lambda first context-switches, so a `foreach` over this body
+                // can point its propagation error at the real `... @name` call (see below).
+                if (cast(void*) sc.func !in inferredCallerAttrLocByFunc)
+                    inferredCallerAttrLocByFunc[cast(void*) sc.func] = ce.loc;
+            }
             else
+            {
+                // For a compiler-generated `foreach`->`opApply` call (auto-marked, no user marker),
+                // report at the context-switching call inside the loop body and word it for the
+                // foreach case, instead of pointing at the generated call site.
+                if (ce.callerAttrAutoMarked && ce.arguments)
+                {
+                    foreach (a; *ce.arguments)
+                    {
+                        auto bodyFd = argCallable(a);
+                        if (bodyFd)
+                            if (auto p = cast(void*) bodyFd in inferredCallerAttrLocByFunc)
+                            {
+                                error(*p, "non-`@%.*s` %s `%s` context-switches here (via `foreach` over `@%.*s` function `%s`)",
+                                    cast(int) name.length, name.ptr, sc.func.kind(), sc.func.toPrettyChars(),
+                                    cast(int) name.length, name.ptr, callee.toPrettyChars());
+                                return 0;
+                            }
+                    }
+                }
                 error(ce.loc, "non-`@%.*s` %s `%s` cannot call `@%.*s` function `%s`",
                     cast(int) name.length, name.ptr, sc.func.kind(), sc.func.toPrettyChars(),
                     cast(int) name.length, name.ptr, callee.toPrettyChars());
+            }
         }
         return 0;
     });
@@ -16423,6 +16451,10 @@ private void checkCallerAttr(CallExp ce, Scope* sc, Dsymbol callee)
 // Side table of caller-attributes inferred on function literals (lambdas), keyed by
 // the literal's declaration. Avoids adding a field to the C++-mirrored FuncDeclaration.
 private __gshared const(char)[][][void*] inferredCallerAttrsByFunc;
+
+// Side table: where each lambda first performs a context-switching call. Used to point a `foreach`'s
+// propagation error at the real `... @ATTR` call inside the loop body (the body is lowered to this lambda).
+private __gshared Loc[void*] inferredCallerAttrLocByFunc;
 
 private void recordInferredCallerAttr(FuncDeclaration fd, const(char)[] name)
 {
@@ -16536,6 +16568,97 @@ private void checkCallerAttrArgs(CallExp ce, Scope* sc, TypeFunction tf)
             foreach (n; *existing)
                 checkName(n);
     }
+}
+
+/******************************************
+ * Option A overload tie-breaker. Two overloads can match a call identically by type yet differ only
+ * by a parameter's caller-required attribute (a UDA, not part of the type), which makes the call
+ * ambiguous. Prefer the overload whose parameter caller-attrs best fit the arguments': a
+ * context-switching callable argument selects the overload whose matching parameter carries the
+ * attribute; a plain argument selects the overload whose parameter does not. Returns the preferred
+ * function, or null when caller-attributes are not involved / do not disambiguate.
+ */
+FuncDeclaration disambiguateCallerAttrOverload(FuncDeclaration f1, FuncDeclaration f2, Expressions* fargs, Scope* sc)
+{
+    if (!fargs || !f1 || !f2)
+        return null;
+
+    // Caller-attr names carried by a parameter (real or fake).
+    static void paramCallerAttrNames(Parameter p, Scope* sc, ref const(char)[][] names)
+    {
+        if (!p || !p.userAttribDecl)
+            return;
+        auto udas = p.userAttribDecl.getAttributes();
+        arrayExpressionSemantic(udas.peekSlice(), sc, true);
+        foreach (uda; *udas)
+        {
+            auto tup = uda.isTupleExp();
+            if (!tup)
+                continue;
+            foreach (e; *tup.exps)
+            {
+                const(char)[] n; bool f;
+                if (isCallerAttrExp(e, n, f))
+                    names ~= n;
+            }
+        }
+    }
+    // Caller-attr names carried by a callable argument (explicit non-fake UDA + inferred on a lambda).
+    static void calleeCallerAttrNames(FuncDeclaration callee, Scope* sc, ref const(char)[][] names)
+    {
+        foreachUda(callee, sc, (Expression e) {
+            const(char)[] n; bool f;
+            if (isCallerAttrExp(e, n, f) && !f)
+                names ~= n;
+            return 0;
+        });
+        if (auto existing = cast(void*) callee in inferredCallerAttrsByFunc)
+            foreach (n; *existing)
+                names ~= n;
+    }
+    static bool hasName(const(char)[][] names, const(char)[] n)
+    {
+        foreach (x; names)
+            if (x == n)
+                return true;
+        return false;
+    }
+
+    bool relevant = false;
+    int mismatches(FuncDeclaration f)
+    {
+        auto tf = f.type ? f.type.isTypeFunction() : null;
+        if (!tf)
+            return int.max;
+        const np = tf.parameterList.length;
+        int m = 0;
+        foreach (i, arg; (*fargs)[])
+        {
+            if (i >= np)
+                break;
+            auto callable = argCallable(arg);
+            if (!callable)
+                continue;
+            const(char)[][] an, pn;
+            calleeCallerAttrNames(callable, sc, an);
+            paramCallerAttrNames(tf.parameterList[i], sc, pn);
+            if (an.length || pn.length)
+                relevant = true;
+            foreach (n; an) if (!hasName(pn, n)) m++;   // arg carries it, the parameter doesn't
+            foreach (n; pn) if (!hasName(an, n)) m++;   // parameter carries it, the arg doesn't
+        }
+        return m;
+    }
+
+    const m1 = mismatches(f1);
+    const m2 = mismatches(f2);
+    if (!relevant)
+        return null;
+    if (m1 < m2)
+        return f1;
+    if (m2 < m1)
+        return f2;
+    return null;
 }
 
 private bool checkFunctionAttributes(Expression exp, Scope* sc, FuncDeclaration f)

--- a/dmd/funcsem.d
+++ b/dmd/funcsem.d
@@ -1517,6 +1517,21 @@ FuncDeclaration resolveFuncCall(const ref Loc loc, Scope* sc, Dsymbol s,
     functionResolve(m, s, loc, sc, tiargs, tthis, argumentList);
     auto orig_s = s;
 
+    // Option A (caller-required attributes): two overloads can match identically by type yet differ
+    // only by a parameter's caller-attr (a UDA, not part of the type), making the call ambiguous.
+    // Break the tie by argument caller-attr fit (e.g. a context-switching `foreach` body selects the
+    // `@CTX_SWITCH` opApply; a plain body the plain one). Only runs when resolution is already
+    // ambiguous, so non-ambiguous calls are unaffected.
+    if (m.last > MATCH.nomatch && m.count > 1 && m.lastf && m.nextf)
+    {
+        import dmd.expressionsem : disambiguateCallerAttrOverload;
+        if (auto winner = disambiguateCallerAttrOverload(m.lastf, m.nextf, fargs, sc))
+        {
+            m.lastf = winner;
+            m.count = 1;
+        }
+    }
+
     if (m.last > MATCH.nomatch && m.lastf)
     {
         if (m.count == 1) // exactly one match

--- a/dmd/id.d
+++ b/dmd/id.d
@@ -529,6 +529,7 @@ immutable Msgtable[] msgtable =
     { "udaOptional", "optional"},
     { "udaMustUse", "mustuse" },
     { "udaStandalone", "standalone" },
+    { "udaCallerAttr", "callerAttr" },
 
     // C names, for undefined identifier error messages
     { "NULL" },

--- a/dmd/parse.d
+++ b/dmd/parse.d
@@ -8966,6 +8966,26 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                 error("identifier or `new` expected following `.`, not `%s`", token.toChars());
                 break;
 
+            case TOK.at:
+                // Caller-required attribute call-site marker: `callee(args) @CTX_SWITCH`.
+                // Attaches the marker identifier to the (call) expression it follows.
+                if (peekNext() == TOK.identifier)
+                {
+                    nextToken();            // skip `@`
+                    Identifier id = token.ident;
+                    nextToken();            // skip the marker identifier
+                    auto ce = e.isCallExp();
+                    if (!ce)
+                    {
+                        // no-parens form: `callee @CTX_SWITCH` is a marked zero-arg call
+                        ce = new AST.CallExp(loc, e);
+                        e = ce;
+                    }
+                    ce.markedCallerAttr = id;
+                    continue;
+                }
+                return e;
+
             case TOK.plusPlus:
                 e = new AST.PostExp(EXP.plusPlus, loc, e);
                 break;

--- a/dmd/statementsem.d
+++ b/dmd/statementsem.d
@@ -3762,8 +3762,13 @@ private extern(D) Expression applyOpApply(ForeachStatement fs, Expression flde,
      */
     Expression ec;
     ec = new DotIdExp(fs.loc, fs.aggr, sapply.ident);
-    ec = new CallExp(fs.loc, ec, flde);
-    ec = ec.expressionSemantic(sc2);
+    auto applyCall = new CallExp(fs.loc, ec, flde);
+    // Option A (caller-required attributes): this `aggr.opApply(body)` is compiler-generated, with no
+    // place for a user `() @ATTR` marker. Flag it as implicitly marked so that when the loop body is
+    // context-switching (and overload resolution selects a `@CTX_SWITCH` opApply), the call is allowed
+    // without a written marker while still propagating the attribute to the enclosing function.
+    applyCall.callerAttrAutoMarked = true;
+    ec = applyCall.expressionSemantic(sc2);
     if (ec.isErrorExp())
         return null;
     if (ec.type != Type.tint32)

--- a/docs/ctx-switch-marking-spec.md
+++ b/docs/ctx-switch-marking-spec.md
@@ -1,0 +1,374 @@
+# Spec: Marking Context-Switching Functions in D
+
+**Status:** Draft — options exploration
+**Goal:** Provide a **general, reusable** language/compiler mechanism for *caller-required, call-site-visible* function attributes. Marking context-switching functions (yielding control from a Weka fiber — any operation that can suspend the current fiber) is the **first client / motivating use case**, not the whole feature. The core requirement: **at the call site it is visible whether the callee carries the attribute** (e.g. can context-switch).
+
+> Terminology used below: a function that may context-switch is *CS-capable*. The property we want to track and surface is "this call may yield the fiber". `CTX_SWITCH` is used throughout as a concrete instance of a generic *caller-required attribute*.
+
+---
+
+## Design axes (what the options vary along)
+
+- **Where the mark lives:** in the *type system* (a token type / parameter) vs. as a *function attribute* (UDA / storage class).
+- **Call-site obligation:** none / signature-only-visible / mandatory per-call-site syntax.
+- **Propagation:** none / inferred / explicit / hybrid.
+- **Generality:** bespoke single attribute vs. general user-definable caller-required-attribute facility.
+- **Implementation surface:** druntime-only, frontend-semantic-only, or frontend-semantic + new parser syntax.
+
+The recommended options (**A**, then **B**) are presented first; the weaker alternatives (**C**, **D**, **E**) follow as rejected alternatives.
+
+---
+
+## The generalized facility (shared by Options A and B)
+
+Options A and B are the **recommended** direction and the **same mechanism** — your `callerAttr` / `callerAttrFake` sketch, generalized — differing **only** in how the call-site marker is *spelled*. Instead of hard-coding "context switch," a library declares a *named caller-required attribute*; the compiler enforces (a) upward propagation and (b) the mandatory call-site marker for any function tagged with it. Context-switch is the first client.
+
+```d
+alias CTX_SWITCH      = callerAttr("CTX_SWITCH", Yes.requireAtCallSites);
+alias CTX_SWITCH_FAKE = callerAttrFake("CTX_SWITCH", Yes.requireAtCallSites);
+```
+
+**`callerAttrFake`:** marks a function as *carrying* the attribute for forwarding/delegate-parameter purposes **without** making it a propagation source to its own callers.
+
+Shared pros/cons of the generalized facility (independent of spelling):
+
+| Pros | Cons |
+|---|---|
+| **One mechanism, many capabilities** — context-switch today, "holds-lock"/"blocking"/"realtime-unsafe" later, all with consistent semantics and tooling. | Must define how a *value/alias* (`callerAttr(...)`) becomes a compiler-enforced attribute — a genuinely new concept; today only fixed `isCoreUda` markers are special. |
+| Parameter-level annotation (`@CTX_SWITCH void delegate() dg`) gives precise rules for delegates/forwarders — directly models the `withFunc` case that bespoke Option D handles only with extra rules. | Adds a registration/identity model for user-defined attributes (cross-module identity, templates, separate compilation — see Q3). |
+| `requireAtCallSites` flag makes call-site obligation a per-attribute policy — flexible. | Highest maintenance; the most surface for subtle soundness bugs. |
+| Clean separation: druntime declares attributes, frontend provides one generic enforcer. | Risk of over-engineering if context-switch turns out to be the only real client. |
+
+The two options below inherit all of the above; the tables only list what the **spelling choice** adds or removes.
+
+---
+
+## Option A — Generalized `callerAttr` with `.ATTR` call-site marker (member-access) — RECOMMENDED
+
+> **Tooling intrusiveness: near-NON-INTRUSIVE.** The marker is spelled as ordinary member access, which existing parsers already accept → files keep parsing everywhere; only minor semantic-resolution noise around the marker token. See [Tooling & ecosystem intrusiveness](#tooling--ecosystem-intrusiveness).
+
+The call-site marker is spelled as a postfix dot: `callee.ATTR(args)` (your latest proposal). The compiler intercepts a `DotIdExp` whose trailing identifier resolves, in the enclosing scope, to a `callerAttr` alias, and reinterprets `LEFT.ATTR(args)` as "call `LEFT(args)`, marked `ATTR`" — so `ATTR` is **never** looked up as a real member of `LEFT`. Enforcement, propagation, and "fake" semantics are identical to Option B.
+
+```d
+alias CTX_SWITCH = callerAttr("CTX_SWITCH");
+
+@CTX_SWITCH void g() {
+    withFunc.CTX_SWITCH({ foo.CTX_SWITCH; });
+    f.CTX_SWITCH(1, 2, 3);
+}
+```
+
+**Why this is the lead option:** `callee.ATTR(args)` and `callee.ATTR` are **already valid D grammar**. Every third-party parser already accepts them, so the catastrophic failure mode of Option B (whole-module parse error → all features off) **does not occur** — and it's also less compiler work.
+
+| Pros (vs. B) | Cons (vs. B) |
+|---|---|
+| **No grammar change at all.** libdparse, Visual D, IntelliJ-D, tree-sitter-d, dfmt, highlighters all keep parsing the file. The single biggest advantage over `@`. | The marker is **lexically indistinguishable from real member access / UFCS**. The compiler must reserve the alias identifier in dot-resolution; a real member or UFCS function of the same name collides (needs a resolution rule — Q6). |
+| **Graceful degradation, not collapse:** DCD/serve-d still parse the file, so GoToDefinition/References keep working for *every other* symbol. Only the marker token itself may not resolve → at worst a "cannot resolve `CTX_SWITCH`" squiggle, not a dead file. | DCD may still try to *autocomplete* `.CTX_SWITCH` as a member and offer nothing/wrong; "find references" on a same-named real member could be muddied. **Semantic** tooling is mildly affected even though **parsing** is not. |
+| Reuses the existing `DotIdExp` AST node; interception is a localized semantic hook, **no parser/AST changes** — strictly less compiler work than Option B. | Less visually distinctive than `@` — `.CTX_SWITCH` can read like an ordinary field/method to a human skimming. Still greppable, but weaker as a "this is special" signal. |
+| Satisfies the **hard per-call-site visibility requirement** — the marker is right at the call. | Chaining/precedence needs a rule: in `a.b().CTX_SWITCH()`, the marker binds the immediately-preceding callable; `a.CTX_SWITCH.b()` is something else. Must be specified. |
+| Clean and refactor-safe — uses **real grammar**, not a comment/pragma kludge. | The no-parens form `foo.CTX_SWITCH;` overlaps with property/UFCS call syntax; meaning ("marked call of `foo` with no args") must be defined and distinguished from a marked property access. |
+
+**Implementation cost:** High — the generalized facility **plus** a `DotIdExp` interception rule and collision-resolution logic in member lookup, but **no parser/AST/grammar work**. Lower total compiler cost than Option B, and far lower ecosystem cost.
+
+---
+
+## Option B — Generalized `callerAttr` with `@ATTR` call-site marker
+
+> **Tooling intrusiveness: INTRUSIVE.** New `@ATTR` expression syntax breaks the libdparse-based stack (DCD GoToDefinition/References, serve-d, dfmt, D-Scanner), Visual D, IntelliJ-D, and third-party highlighters until each is patched. See [Tooling & ecosystem intrusiveness](#tooling--ecosystem-intrusiveness).
+
+Same mechanism as Option A, but the call-site marker is a postfix `@ATTR` between the callee and its arguments: `callee@ATTR(args)`. This is your examples 2/3 spelling.
+
+```d
+@CTX_SWITCH_FAKE void withFunc(@CTX_SWITCH void delegate() dg) { dg@CTX_SWITCH(); }
+@CTX_SWITCH      void g() { f@CTX_SWITCH(1, 2, 3); }
+```
+
+| Pros (vs. A) | Cons (vs. A) |
+|---|---|
+| **Most visually distinctive** — `@CTX_SWITCH` cannot be mistaken for an ordinary field/method; strongest "this is special" signal. | **Intrusive: breaks the third-party tooling ecosystem** (whole-module parse failure → GoToDefinition/References/format/lint disabled on affected files) until every independent parser is patched. |
+| No ambiguity with real members/UFCS — `@` is unambiguously the marker. | **New expression grammar** with no precedent: requires parser + AST + expression-semantic plumbing (`parsePostExp` has no `@` handling today). Highest compiler cost of any option. |
+| | Hardest to maintain against upstream DMD frontend rebases (fork divergence in the parser). |
+
+**Implementation cost:** Very High — the generalized facility **plus** net-new call-site grammar/AST.
+
+---
+
+## Option C — Type-token parameter (`ctxsw` value threaded through calls)
+
+> **Tooling intrusiveness: NON-INTRUSIVE.** No grammar change; GoToDefinition/References and all editor tooling keep working. See [Tooling & ecosystem intrusiveness](#tooling--ecosystem-intrusiveness).
+
+*Rejected alternative.* Your example 1. A magic, non-constructible token type (`struct ctxsw` with `@disable this()`) is passed as a parameter to every CS-capable function; callers must thread a `CTXSW` value through.
+
+```d
+void boom(ctxsw CTXSW) {}
+auto f(ctxsw CTXSW) { return (ctxsw CTXSW) => boom(CTXSW); }
+```
+
+**How visibility works:** the capability is encoded in the *signature* (the function has a `ctxsw` parameter) and the token must be physically passed at the call. The token "infects" any function that wants to call a CS-capable function — it must itself receive one to have a value to pass.
+
+| Pros | Cons |
+|---|---|
+| **Zero new language features** — pure library + existing UDAs. No fork risk, trivially upstream-neutral. | Call site reads as an ordinary argument (`boom(CTXSW)`), **not** a distinctive marker; visibility is weak unless you grep for the token. |
+| Propagation is automatic and sound: you *cannot* call a CS-capable fn without already holding a token, which you only get by being CS-capable yourself. | Intrusive on every signature and every call; churns existing code heavily. Interacts awkwardly with delegates, overload sets, `opXXX`, UFCS, and existing APIs that can't take the extra param. |
+| Works with templates/IFTI naturally (token is just a parameter). | Token must be materialized somewhere (`ctxsw CTXSW = void;`), and `@disable this()` + `void`-init is a hole that can be abused to forge a token. |
+| Easy to prototype today; no compiler change strictly required. | Depends on `@nocapture` semantics that **do not exist yet** in this repo; without real capture-checking the token can be captured/escaped, weakening guarantees. Runtime cost unless the param is elided. |
+
+**Implementation cost:** Low if accepted as "convention + library"; Medium if you want real escape/capture guarantees (`@nocapture` would have to be designed and implemented — it is absent today).
+
+**Why rejected:** call-site visibility is too weak (a token argument is not a distinctive marker), and it depends on `@nocapture`, which does not exist.
+
+---
+
+## Option D — Bespoke function attribute **plus mandatory `@` call-site annotation** (`f@CTX_SWITCH(...)`)
+
+> **Tooling intrusiveness: INTRUSIVE.** New `@ATTR` expression syntax breaks libdparse-based tooling (DCD GoToDefinition/References, serve-d, dfmt, D-Scanner), Visual D, IntelliJ-D, and third-party highlighters until each is patched. See [Tooling & ecosystem intrusiveness](#tooling--ecosystem-intrusiveness).
+
+*Rejected alternative.* Your examples 2/3, specialized to context-switch. A built-in marker `@CTX_SWITCH` carried on the function declaration, **plus** the rule that **every call to a CS-capable function must be written with a call-site marker** `f@CTX_SWITCH(...)` (and `dg@CTX_SWITCH()` for delegates), or it is a compile error.
+
+```d
+@CTX_SWITCH void g() {
+    withFunc@CTX_SWITCH({ foo@CTX_SWITCH; });
+    f@CTX_SWITCH(1,2,3);
+}
+```
+
+| Pros | Cons |
+|---|---|
+| **Best possible call-site visibility** — literally the strong per-call-site marker requirement; impossible to miss a yielding call. | **New expression syntax** with no precedent: `parsePostExp` (`parse.d:8938`) has no `@` handling, and `@` is currently only a declaration-level token. Requires grammar changes, new AST, and disambiguation against existing `@` uses. |
+| Acts as executable documentation and as a diff-review signal (reviewers see new yield points appear). | Intrusive to the third-party tooling ecosystem (same blast radius as Option B). |
+| Built-in caller-must-match enforcement (the `@nogc` direction) also forces the enclosing function to be marked. | Verbose; every call site changes. Tooling (formatters, IDEs, ddoc, `__traits`) must learn the new syntax. |
+
+**Implementation cost:** High. Frontend semantic work (clone the `@nogc` enforcement/inference slice) **plus** net-new parser + AST + expression-semantic plumbing for the postfix `@ATTR` form.
+
+**Why rejected:** the right shape, but hard-wired to a single attribute rather than reusable — **Option B is exactly this generalized**, and Option A achieves the same goal without breaking tooling. Kept only as the conceptual precursor to Option B.
+
+---
+
+## Option E — No language change: convention + static analysis / naming
+
+> **Tooling intrusiveness: NON-INTRUSIVE.** No grammar change; a lint tool is additive (typically built on libdparse itself). See [Tooling & ecosystem intrusiveness](#tooling--ecosystem-intrusiveness).
+
+*Rejected alternative.* Encode the capability by **naming convention** (e.g. suffix `_cs` / `_yields`) and/or an out-of-band **linter** (DScanner plugin, or a custom AST pass over the frontend) that flags CS-capable calls and verifies propagation, without touching the language.
+
+| Pros | Cons |
+|---|---|
+| Zero compiler/fork risk; ships immediately; fully upstream-neutral. | **Not enforced by the type system** — guarantees are advisory; easy to bypass or forget. |
+| Call-site visibility achievable via naming (`yieldNow()` reads as yielding). | Naming discipline is brittle across refactors, templates, aliases, and third-party code. |
+| Can be layered under any other option later as a stepping stone. | A separate linter is its own maintenance burden and won't see template instantiations the way the frontend does. |
+
+**Implementation cost:** Low–Medium (linter), or ~Zero (convention only).
+
+**Why rejected:** advisory only — no compiler-enforced guarantee, which the propagation requirement demands. Still useful as a migration bridge.
+
+---
+
+## Comparison matrix
+
+Options are ordered best-first. A and B are the same generalized mechanism; they differ only in the call-site marker spelling (`.ATTR` vs `@ATTR`).
+
+| | A. Generalized `.ATTR` | B. Generalized `@ATTR` | C. Type token | D. Bespoke `@` | E. Convention/lint |
+|---|---|---|---|---|---|
+| Call-site visibility | **Strong (per call)** | **Strong (per call)** | Weak (looks like arg) | **Strong (per call)** | Weak–Medium |
+| Propagation soundness | Strong | Strong | Automatic | Strong (inferred) | None (advisory) |
+| New syntax? | No (reuses member-access) | **Yes (`@`)** | No | **Yes (`@`)** | No |
+| Reuses existing frontend path | Minimal + `DotIdExp` hook | Minimal | Partial | Partial + new | n/a |
+| Models `withFunc`/delegate forwarder | **Native** | **Native** | Clumsy | Needs extra rule | n/a |
+| Upstreamable / low fork risk | No | No | **Yes** | No | **Yes** |
+| Implementation cost | High (no parser work) | Very High | Low–Med | High | Low |
+| Generality (future attrs) | **Yes** | **Yes** | No | No | No |
+| Intrusive to 3rd-party parsers / editors? | **near-No** | **Yes** | No | **Yes** | No |
+| Marker distinctiveness (human reader) | Medium (`.` reads like member) | **Strong (`@`)** | Weak | **Strong (`@`)** | Naming-dependent |
+
+---
+
+## Tooling & ecosystem intrusiveness
+
+A change to the **compiler** is not the same as a change to the **language as the tooling ecosystem sees it**. Almost the entire D editor/IDE stack parses D source with its *own* parser — **not** the DMD/LDC frontend we're forking. So any change to *grammar* (not just semantics) breaks those tools until each is independently patched, and we do **not** control most of them.
+
+**The dividing line:** changes that are only new *attributes* (declaration-side UDAs) or *semantic rules* parse fine with existing grammars and are **non-intrusive** to tooling. Changes that add new *expression/statement syntax* — specifically the `@` call-site marker `foo@CTX_SWITCH(args)` — are **intrusive**: third-party parsers encounter an unexpected `@` in expression position, fail to parse the **whole module**, and (because these tools degrade per-file, not per-line) silently disable their features for that file. **Option A's `.ATTR` spelling sidesteps this entirely** because member access is already valid grammar.
+
+### What breaks, and the user-visible symptom
+
+For any option that introduces the call-site `@ATTR` expression syntax (**B and D**; **A avoids this entirely** by using member-access spelling):
+
+- **libdparse** (the community D parser library) — does not recognize postfix `@` on expressions → parse error. This is the root dependency for most of the list below, so a single libdparse gap cascades:
+  - **DCD** (D Completion Daemon) → **GoToDefinition / GoToReferences / autocomplete stop working** for any file containing a call-site marker (and often for symbols it transitively needs from such files).
+  - **serve-d / code-d** (the VS Code D extension) → diagnostics, hover, rename, outline, semantic highlight all degrade on affected files.
+  - **dfmt** (formatter) → fails or corrupts formatting around the marker.
+  - **D-Scanner** (linter/static analysis) → spurious parse errors, lint disabled for the file.
+- **Visual D** (Visual Studio) and the **IntelliJ-D / JetBrains** plugin ship **independent** parsers/grammars → same breakage, separately.
+- **Syntax highlighters** with their own grammars — TextMate/`.tmLanguage` bundles, **tree-sitter-d**, Pygments, GitHub Linguist → mis-highlight or error around `@` in call position (cosmetic but pervasive: GitHub/GitLab diffs, docs).
+- **ctags / universal-ctags** D parser and **ddoc/ddox** doc generators → may mis-tag or skip affected declarations.
+
+> Note: the **declaration-side** pieces — `@CTX_SWITCH` as a UDA on a function, and `callerAttr!"..."` / `callerAttrFake!"..."` as ordinary template aliases — parse with **existing** grammars and are **non-intrusive** in every option. Only the **`@` call-site marker** is the intrusive part — which is exactly why Option A's `.ATTR` spelling is the lead recommendation.
+
+### Per-option intrusiveness
+
+- **Option A (generalized `.ATTR`)** — **Near-non-intrusive.** Member-access spelling is already valid grammar → no parse failures; tooling degrades only on the marker token (e.g. an unresolved-symbol squiggle), not the whole file. GoToDefinition/References keep working for every other symbol.
+- **Option B (generalized `@ATTR`)** — **Intrusive.** New `@ATTR` expression grammar → breaks the libdparse-based stack (DCD GoToDefinition/References, serve-d, dfmt, D-Scanner), Visual D, IntelliJ-D, and third-party highlighters until each is patched.
+- **Option C (type token)** — **Non-intrusive.** No grammar change; a `ctxsw` parameter and `boom(CTXSW)` call are ordinary D. All editor tooling keeps working unchanged.
+- **Option D (bespoke attribute + `@` call-site syntax)** — **Intrusive (same blast radius as B).** Identical `@ATTR` grammar.
+- **Option E (convention/lint)** — **Non-intrusive.** No grammar change; a lint tool is purely additive (and itself typically built *on* libdparse, so it inherits, not breaks, the ecosystem).
+
+### Mitigations (only relevant if the `@`-marker path B / D is chosen)
+
+Since we own a **Weka-local fork**, the breakage is in the *surrounding tools*, not the compiler. Options to limit blast radius, in rough order of effort/robustness:
+
+1. **Lexer-level concealment for non-fork tools.** Make the marker lexically skippable — e.g. spell it as something existing grammars already tolerate (a special comment/pragma form, or a `mixin`/template-call wrapper) so libdparse/highlighters see valid tokens. Trades syntactic elegance for zero ecosystem breakage. *(Feasibility depends on Q4's chosen spelling — flagged there.)*
+2. **Patch + vendor libdparse.** Maintain a fork of libdparse with the new grammar and rebuild DCD/serve-d/dfmt/D-Scanner against it. High maintenance (mirrors the compiler-fork cost across N tools) but preserves real tooling.
+3. **Editor-side preprocessing.** A thin layer that strips/normalizes `@ATTR` markers before handing source to DCD/dfmt, restoring them after. Brittle for rename/refactor.
+4. **Accept degraded tooling on marked files**, relying on the compiler for correctness and treating editor features as best-effort. Lowest effort, worst developer experience.
+
+This is the **core trade-off between Options A and B (Q4)**: **Option A *is* mitigation 1 done properly** — it uses real member-access grammar instead of a comment/pragma kludge, so it sidesteps the entire intrusiveness problem without any of the mitigations above. Unless Option B's stronger visual distinctiveness is worth breaking the tooling ecosystem, **Option A is the answer**.
+
+---
+
+## Decision
+
+**Chosen: the generalized, user-definable caller-required-attribute facility — Option A or B.** The mechanism is settled; the only open choice is the call-site marker spelling: **A (`.ATTR`, recommended)** vs **B (`@ATTR`)** — decided in Q4. The settled requirements driving this:
+
+- **Mandatory call-site visibility.** A reader must be able to look at *the call itself* and know whether it context-switches; signature-only visibility is insufficient. → a per-call-site marker is required.
+- **Enforced upward propagation.** A function that is not `CTX_SWITCH` may not call a `CTX_SWITCH` function. The capability propagates strictly upward to exactly **one root** — the fiber main function — which is declared `CTX_SWITCH` at the top, closing the tree.
+- **Reusable mechanism.** The facility is generic (`callerAttr`); `CTX_SWITCH` is just the first client.
+- **"Fake" migration mode.** Converting the whole source tree at once is infeasible, so a "fake" mode lets a function carry/forward the attribute (or call CS functions) *without* yet forcing the requirement onto its callers — a deliberate, greppable migration boundary.
+- **Weka-local fork.** Upstreaming is not required, so new syntax (Option B) is on the table — though Option A's member-access spelling avoids any grammar change and the resulting tooling breakage.
+
+**Recommendation:** prefer **Option A (`.ATTR`)** — near-zero ecosystem cost and lower compiler cost; its price is the member-access collision rule (Q6). Choose **Option B (`@ATTR`)** only if its stronger visual distinctiveness is judged worth breaking the third-party tooling ecosystem (DCD GoToDefinition/References, serve-d, dfmt, Visual D, IntelliJ-D).
+
+Options C, D, E are retained above as **rejected alternatives**: C/E give insufficient call-site visibility/enforcement; D is the right shape but hard-wired to one attribute rather than reusable (Option B is D generalized — so D's implementation notes are a strict subset of B's).
+
+The remaining open points (spelling A vs B, inference vs. explicit annotation, exact "fake" semantics, attribute identity across modules) are captured in the **Open questions** section below; everything else is specified in the design section that follows.
+
+---
+
+## Chosen design — Options A/B in detail
+
+This section specifies the shared mechanism. Everything is spelling-agnostic except **step 3 (the call-site marker)**, which gives both the A (`.ATTR`) and B (`@ATTR`) forms.
+
+### 1. Declaring an attribute
+
+A caller-required attribute is introduced once, in library code, and given a compile-time identity:
+
+```d
+// druntime / weka runtime
+alias CTX_SWITCH      = callerAttr!("CTX_SWITCH");          // the real attribute
+alias CTX_SWITCH_FAKE = callerAttrFake!("CTX_SWITCH");      // migration escape hatch for the same attribute
+```
+
+`callerAttr!"Name"` yields a compiler-recognized UDA whose **identity is the string name** (so the same name in two modules refers to the same attribute — see Q3 on identity model). `callerAttrFake!"Name"` refers to the *same* attribute but flips the propagation behavior (step 4).
+
+### 2. Marking declarations
+
+Any function (and, for forwarders, any *delegate/function-pointer parameter*) can carry the attribute:
+
+```d
+@CTX_SWITCH void foo();                        // foo may context-switch
+@CTX_SWITCH void withFunc(@CTX_SWITCH void delegate() dg);  // param dg is CS-capable
+```
+
+The **root** of the capability tree is just a function the programmer declares `@CTX_SWITCH` at the top (the fiber main); nothing calls it without itself being `@CTX_SWITCH`, so the tree is closed.
+
+### 3. Mandatory call-site marker (the hard requirement)
+
+Calling a function/delegate that carries attribute `X` **must** be written with a postfix marker, or it is a compile error; conversely writing the marker on a non-`X` call is also an error (the marker must match reality). The marker is spelled per the chosen option:
+
+**Option A — `.ATTR` form (member-access spelling, recommended):**
+
+```d
+@CTX_SWITCH void g() {
+    foo.CTX_SWITCH();                 // OK — marker matches
+    withFunc.CTX_SWITCH({
+        bar.CTX_SWITCH();
+    });
+    plain();                          // OK — plain() is not @CTX_SWITCH, no marker
+    foo();                            // ERROR: call to @CTX_SWITCH `foo` must be marked `foo.CTX_SWITCH(...)`
+}
+```
+
+**Option B — `@ATTR` form:**
+
+```d
+@CTX_SWITCH void g() {
+    foo@CTX_SWITCH();                 // OK — marker matches
+    withFunc@CTX_SWITCH({             // OK
+        bar@CTX_SWITCH();             // delegate body is itself CS-capable
+    });
+    plain();                          // OK
+    foo();                            // ERROR: call to @CTX_SWITCH `foo` must be marked `foo@CTX_SWITCH(...)`
+}
+```
+
+Grammar:
+- **Option A:** no grammar change — `callee.ATTR(args)` is parsed as an ordinary `DotIdExp`; the compiler intercepts it semantically when `ATTR` resolves to a `callerAttr` alias (collision rule: Q6).
+- **Option B:** a postfix `@Identifier` between callee and arguments — `PostfixExpression '@' Identifier '(' Arguments ')'`. New expression grammar (parser + AST work; intrusive to tooling).
+
+### 4. Propagation rule
+
+For a real attribute `X` (`callerAttr`):
+
+> A function body that contains a call marked with `X` is itself required to carry `@X`. A function **not** carrying `@X` that performs an `X`-marked call is a compile error (it must be annotated `@X`). Capability therefore propagates strictly upward to the single root.
+
+This is the `@nogc` enforcement direction reused (`checkNogc` → `checkCallerAttr`), but with the **call-site marker** as the additional gate.
+
+### 5. The "fake" mode (migration)
+
+`callerAttrFake!"X"` exists so the tree can be converted incrementally instead of in one mega-commit. A `@X_FAKE` function:
+
+- **is allowed to make `X`-marked calls** (so you can start threading the attribute through hot paths), **but**
+- **does not propagate the requirement to its callers** — callers may call it *without* a marker and without being `@X` themselves.
+
+This makes `@X_FAKE` a deliberate, greppable soundness hole that marks "migration boundary — not yet fully threaded." It also covers the forwarder case from your example (`withFunc` annotated fake while its `@X` delegate parameter is honored). **Q2** pins down whether "fake" should additionally require the call-site marker (for visibility) even though it doesn't propagate.
+
+### 6. Interactions to specify (tracked, not yet decided)
+
+- **Delegates / function pointers:** the attribute is part of the *type* (`@CTX_SWITCH void delegate()`); calling such a delegate needs the marker. Implies a `TypeFunction` flag (`mtype.d:3047`) and mangling consideration.
+- **Templates / `auto` / lambdas:** inference vs. explicit (Q1).
+- **Function pointers stored in variables, virtual calls, `opCall`, UFCS, `alias`:** marker placement rules needed.
+- **`__traits`/reflection:** expose "has caller-attr X" for tooling.
+- **Mangling & separate compilation:** does the attribute affect the symbol name (like `@nogc` does not, but `extern(C++)` ABI tags do)? Affects linking against unconverted libraries during migration.
+
+---
+
+## Open questions (remaining before implementation)
+
+1. **Inference vs. explicit annotation for propagation.** When `g` calls an `@CTX_SWITCH` function, do you want `g` to be **inferred** `@CTX_SWITCH` automatically (less annotation churn, but the propagation becomes invisible at `g`'s declaration), or must `g` be **explicitly** annotated `@CTX_SWITCH` or it errors (maximally explicit, matches "you always see it", but more verbose)? Note: the *call-site* marker is mandatory regardless; this question is only about whether the *function header* annotation is auto-inferred. For templates/lambdas/`auto`, do you want the `@nogc` hybrid (infer for templates, require for non-templates)?
+   <<answer here>>
+2. **Exact "fake" semantics.** A `@X_FAKE` function does not propagate `@X` to its callers. But should an `@X_FAKE` function still be **required to mark** its own internal `X` calls? Two flavors: (a) *strict-fake* — marker still required inside (keeps visibility, only propagation is suppressed); (b) *loose-fake* — no marker required inside (truly "turn it all off here" for fastest migration). Which do you want — or both, as two different fake aliases?
+   <<answer here>>
+3. **Attribute identity across modules.** Should two `callerAttr!"CTX_SWITCH"` aliases declared in different modules be the **same** attribute (identity = the string name), or should identity be the **alias symbol** (so you must import the one canonical `CTX_SWITCH` declaration)? Symbol identity is safer (no accidental string collisions) but forces a shared import; string identity is looser and simpler.
+   <<answer here>>
+4. **Call-site marker spelling — A vs B (the central choice).** Member-access `.` ([Option A](#option-a--generalized-callerattr-with-attr-call-site-marker-member-access--recommended), recommended) or postfix `@` ([Option B](#option-b--generalized-callerattr-with-attr-call-site-marker))? A is **near-non-intrusive** to tooling and lower compiler cost, but introduces member-access ambiguity (Q6); B is more visually distinctive but breaks the third-party parser ecosystem. (A prefix `@CTX_SWITCH foo(args)` form is a third, less-favored possibility.) And for templates: `foo!(T).CTX_SWITCH(args)` / `foo!(T)@CTX_SWITCH(args)`? **Recommendation: Option A.**
+   <<answer here>>
+5. **Scope of "call".** Besides direct calls, which of these must carry the marker: delegate/function-pointer invocation through a variable, virtual method calls, `opCall`/operator overloads that may switch, and `alias`-ed calls? (Confirm "all invocations of an `@X`-typed callable" is the rule.)
+   <<answer here>>
+6. **(Only if Option A / `.ATTR` spelling chosen) Member-access collision rule.** Since `foo.CTX_SWITCH` is grammatically a member access, what happens when a real member or UFCS function named `CTX_SWITCH` is also in scope? Options: (a) the `callerAttr` alias interpretation always wins (shadows real members of that name — simplest, but can hide a real member); (b) it's a hard error (ambiguous); (c) the marker only applies when `CTX_SWITCH` resolves to a visible `callerAttr` alias and there is no member of that name, else fall back to normal member access. Also: must the alias be imported/visible in the calling scope for the marker to be recognized?
+   <<answer here>>
+
+---
+
+## Appendix: concrete frontend touch-points (Options A / B / D)
+
+- Marker definition: `runtime/druntime/src/core/attribute.d` (pattern: `enum ctxswitch;`).
+- Recognition: extend `isCoreUda`/`isEnumAttribute` (`dmd/attrib.d:1246`/`:1325`); add `Id.udaCtxSwitch`.
+- New STC bit: `dmd/astenums.d:42` (`STC` enum) + mirror flag on `TypeFunction` (`dmd/mtype.d:3047`).
+- Enforcement: new `checkCtxSwitch` beside `checkNogc` (`dmd/expressionsem.d:2174`), called from `checkFunctionAttributes` (`:16279`), invoked in `visit(CallExp)` (`:6625`), respecting an `ignoreAttributes`-style escape hatch (`expression.d:3553`).
+- Inference: `STC.inference` flow in `semantic3` (`:282`) + new `ctxswitchViolation` field (`dmd/func.d:336` neighborhood).
+- Call-site marker:
+  - **Option A (`.ATTR`):** no parser change — intercept `DotIdExp` in `dmd/expressionsem.d` when the trailing identifier resolves to a `callerAttr` alias, before normal member lookup; add collision-resolution (Q6).
+  - **Option B (`@ATTR`):** extend `parsePostExp` (`dmd/parse.d:8938`) for postfix `@ATTR`, add a new AST field on `CallExp`, plumb through `visit(CallExp)`. (Also applies to bespoke Option D.)
+
+---
+
+## Appendix: how the frontend works today (verified)
+
+These facts shape the cost estimates throughout this spec (file:line references into this repo):
+
+- Built-in compiler-recognized UDAs are defined in `runtime/druntime/src/core/attribute.d` as bare `enum` markers (e.g. `enum mustuse;` at line 292) or small structs (`gnuAbiTag`). LDC-specific ones live in `runtime/druntime/src/ldc/attributes.d`.
+- A UDA is recognized as "special" via `isCoreUda` / `isEnumAttribute` (`dmd/attrib.d:1246`, `:1325`); `@mustuse` is the closest existing template — see `dmd/mustuse.d` (`hasMustUseAttribute`, `isMustUseAttribute`, `checkMustUse`).
+- **Caller-must-match attribute checking already exists** for `@safe`/`@nogc`/`pure`/`nothrow`/`@live`. The enforcement hooks are `checkSafety`/`checkNogc` (`dmd/expressionsem.d:2101`, `:2174`), aggregated in `checkFunctionAttributes` (`:16279`) and invoked per call in `visit(CallExp)` (`:6625`, gated by `CallExp.ignoreAttributes` at `:6340`).
+- **Attribute inference** for templates/lambdas/`auto` functions is driven by `STC.inference` (`dmd/astenums.d:105`) during `semantic3` (`dmd/semantic3.d:282`); violations are recorded in per-function fields like `safetyViolation`/`nogcViolation` (`dmd/func.d:336`).
+- Function attributes are stored as `STC` bitflags (`dmd/astenums.d:42`) on `FuncDeclaration.storage_class` and mirrored on `TypeFunction` (`dmd/mtype.d:3047`).
+- **There is NO existing syntax for attributes on expressions / call sites.** `parsePostExp` (`dmd/parse.d:8938`) handles `.`, `++`, `()`, `[]` only — no `@` token. `@`-attributes are parsed for declarations only (`parseAttribute` `dmd/parse.d:1285`).
+- **`@nocapture` does not exist** in this codebase (zero hits). Option C assumes a `@nocapture` import from `core.attribute` that is not present today — it would itself be new work.
+
+The single most important consequence: **enforcing/propagating a function attribute reuses a well-trodden path (the `@nogc` machinery), but a mandatory `@` call-site syntax is genuinely new parser + semantic surface with no precedent in the language** (which is exactly why Option A's `.ATTR` member-access spelling is the lead recommendation — it needs no grammar change).

--- a/docs/ctx-switch-option-a-implementation-spec.md
+++ b/docs/ctx-switch-option-a-implementation-spec.md
@@ -1,0 +1,323 @@
+# Implementation Spec: Option A — Caller-Required Attributes with `.ATTR` Call-Site Marker
+
+**Status:** ✅ Implemented & verified in this tree (Weka-local fork). See [Implementation status](#implementation-status).
+**Implements:** Option A from [`ctx-switch-marking-spec.md`](./ctx-switch-marking-spec.md) — the generalized `callerAttr` facility with the member-access call-site marker (`callee.CTX_SWITCH(args)`).
+**Target:** Weka-local fork of the LDC/DMD frontend (`dmd/`). No upstreaming constraint.
+**Non-goal:** the `@ATTR` spelling (Option B) — explicitly out of scope here.
+
+All file:line references below were verified against the current tree.
+
+---
+
+## Decisions (resolved)
+
+The open questions were resolved as follows and the implementation follows these:
+
+1. **`callerAttr` identity / recognition:** **(a) type-per-name.** `callerAttr!"X"` is a struct *template instance*; identity is read from the template's string value argument — no CTFE of values. Recognized via `isCallerAttrStruct` (parent `TemplateInstance` whose `tempdecl` is the `callerAttr` template in `core.attribute`).
+2. **Propagation:** **explicit-only (v1).** A function that performs a marked call must itself be declared `@CTX_SWITCH` (or `@CTX_SWITCH_FAKE`); inference via `STC.inference` is deferred to a phase 2.
+3. **Collision rule:** the marker fires when the trailing identifier resolves, in the calling scope, to a visible `callerAttr` alias; the alias must be visible in scope. (The "no real member of that name" refinement is left for phase 2; v1 treats a visible `callerAttr` alias as a marker.)
+4. **"Fake" semantics:** **strict-fake.** A `@..._FAKE` function does not propagate the requirement to its callers and callers need no marker, but internal calls inside it still require their markers.
+5. **Call-site scope:** v1 covers **direct calls to named functions, aggregate methods (incl. virtual / `opCall`), and indirect calls through `@CTX_SWITCH` delegate / function-pointer variables** (`scope` and non-`scope` alike). The attribute on a delegate/function-pointer parameter is carried by the parameter's declaration UDA, so it is enforced at the indirect call site. (Not yet: caller-attrs encoded in the delegate *type* itself — so passing a non-CS function to a `@CTX_SWITCH` delegate parameter is not value-side checked; that needs the `TypeFunction` work.)
+
+---
+
+## 1. Approach in one paragraph
+
+`callerAttr!"NAME"` (in druntime) produces a compiler-recognized UDA. A function "carries" attribute `NAME` if its UDA list contains such a value (or, phase 2, if inferred). The call-site marker `callee.NAME(args)` is **ordinary member-access grammar** — no parser change. During expression semantics we intercept the `DotIdExp` `callee.NAME` *before* normal member/UFCS resolution: if `NAME` resolves to a `callerAttr` alias, we rewrite the expression to the plain call `callee(args)` tagged with the required attribute `NAME`, verify the callee actually carries `NAME` ("marker matches reality"), and run a `@nogc`-style caller-must-carry check to enforce upward propagation. Everything reuses existing machinery (`foreachUda`, `checkFunctionAttributes`, the `DotIdExp`/UFCS path); the only genuinely new logic is the marker interception and the per-function "required caller-attr set".
+
+---
+
+## 2. Data model
+
+Because the facility is **generalized** (many named attributes: `CTX_SWITCH`, `HOLDS_LOCK`, …), a single `STC` bit cannot represent membership — a bit can't say *which* attribute. So:
+
+- **Membership (declaration-side):** read from the function's existing UDA list via `foreachUdaNoSemantic`/`foreachUda` (`dmd/attrib.d:1267`,`:1307`). No new storage needed for explicitly-declared attributes.
+- **Inferred set (phase 2):** a new field on `FuncDeclaration`, e.g. `Identifier[] inferredCallerAttrs;` (placed near the violation fields, `dmd/func.d:336`). Empty in explicit-only v1.
+- **Fast-path flag (optional):** one free `STC` bit — `STC` is `enum STC : ulong` with the highest current bit at `STC.volatile_ = 0x40_0000_0000_0000` (`dmd/astenums.d:112`); bits 55–63 are free. A `STC.hasCallerAttr = 0x80_0000_0000_0000` flag lets hot call paths skip the UDA scan when a function carries none. Optional optimization, not required for correctness.
+- **Call-site tag:** a new field on `CallExp` (`dmd/expression.d`, near `ignoreAttributes` at `:3553`), e.g. `Identifier markedCallerAttr;` — set when the call was written with a `.NAME` marker; `null` otherwise. Used to enforce "marker must match reality".
+
+---
+
+## 3. Recognizing `callerAttr` UDAs (identity)
+
+Existing special UDAs are matched by **Identifier + being in `core.attribute`** via `isCoreUda` (`dmd/attrib.d:1246`) / `isEnumAttribute` (`dmd/attrib.d:1325`); `@mustuse` is the template (`dmd/mustuse.d` `isMustUseAttribute`). Those match a *fixed* symbol name — they cannot carry a per-attribute string.
+
+For the generalized facility we recognize the **`callerAttr` template itself** (by symbol identity in a designated module — propose `core.attribute` or `ldc.attributes`), then extract the name:
+
+- **Recommended (Q1a):** `callerAttr!"X"` yields a value whose **type is a template instance** `CallerAttr!("X")` of a template declared in the designated module. Recognition: the UDA expression's type is an instantiation of that template; the name is the instance's first template value argument (a `StringExp`). No value CTFE required — read the `TemplateInstance.tiargs`.
+- **Alternative (Q1b):** one struct type `CallerAttr { string name; bool fake; }`; recognize by type symbol+module, then CTFE the UDA expression to a struct literal and read `.name`/`.fake`.
+
+A helper mirroring `isCoreUda` does the matching:
+
+```
+// dmd/attrib.d (new)
+bool isCallerAttr(Expression uda, out Identifier name, out bool fake);
+```
+
+`callerAttrFake!"X"` is the same template/type with `fake = true`.
+
+---
+
+## 4. druntime side (the only library code)
+
+Proposed (designated module so the frontend can match by symbol). Exact shape depends on Q1; this is the type-per-name form:
+
+```d
+// runtime/druntime/src/core/attribute.d  (or ldc/attributes.d)
+
+struct CallerAttr(string attrName, bool isFake) {
+    enum name = attrName;
+    enum fake = isFake;
+}
+
+// Factory aliases used at the use-site:
+template callerAttr(string name)     { enum callerAttr     = CallerAttr!(name, false)(); }
+template callerAttrFake(string name) { enum callerAttrFake = CallerAttr!(name, true )(); }
+```
+
+Use-site:
+
+```d
+import core.attribute : callerAttr, callerAttrFake;
+
+alias CTX_SWITCH      = callerAttr!"CTX_SWITCH";
+alias CTX_SWITCH_FAKE = callerAttrFake!"CTX_SWITCH";
+```
+
+> The frontend recognizes the `CallerAttr` template by name + module (extend `isCoreUda`). The `Yes.requireAtCallSites` parameter from the design sketch is implicit in v1 (always required); it can become a real template parameter later if a non-call-site-required attribute is ever wanted.
+
+---
+
+## 5. Frontend changes, by phase
+
+### Phase 0 — recognition plumbing
+- Add `Id.callerAttr` / `Id.callerAttrFake` to `dmd/id.d` and the `CallerAttr` recognition to `dmd/attrib.d` (`isCallerAttr`, alongside `isCoreUda` `:1246`).
+- Add `markedCallerAttr` to `CallExp` (`dmd/expression.d:3553` neighborhood) and (optional) `STC.hasCallerAttr` (`dmd/astenums.d:112`).
+- Helper `funcCarriesCallerAttr(FuncDeclaration f, Identifier name)`: scan `f`'s UDAs via `foreachUdaNoSemantic` (`dmd/attrib.d:1307`) + (phase 2) `inferredCallerAttrs`.
+
+### Phase 1 — call-site marker interception (the core)
+The marker `callee.NAME(args)` reaches semantics through the `DotIdExp` path. Intercept in **`resolveUFCS`** (`dmd/expressionsem.d:1087`), which already special-cases a `DotIdExp` callee and calls `die.dotIdSemanticPropX()` (`:1097`) before the UFCS search (`:1193`):
+
+1. After `dotIdSemanticPropX` returns and before UFCS lookup, test `isCallerAttrMarker(die.ident, sc)` — does `die.ident` resolve in `sc` to a visible `callerAttr` alias, with **no** real member of that name on `typeof(die.e1)` (collision rule, Q6c)?
+2. If yes: set `callExp.markedCallerAttr = name`, replace the callee with `die.e1` (the bare callee), and let normal call resolution proceed on `die.e1(args)`.
+3. The no-parens form `foo.NAME;` arrives as a `DotIdExp` not wrapped in a `CallExp`; handle in `visit(DotIdExp)` (`dmd/expressionsem.d:8110`) / `dotIdSemanticProp` (`:14375`): rewrite to a marked zero-arg call `foo()`.
+
+Member-lookup error path to suppress when it's actually a marker: `dotIdSemanticPropX` emits "expression `%s` does not have property `%s`" at `dmd/expressionsem.d:14349-14352` — the interception must run before that fires.
+
+### Phase 2 — enforcement (marker ↔ reality, and propagation)
+Add `checkCallerAttr(CallExp ce, Scope* sc, FuncDeclaration callee)` and call it from `checkFunctionAttributes` (`dmd/expressionsem.d:16279`), which already runs per call in `visit(CallExp)` (`:6625`), gated by `ignoreAttributes` (`:6340`). Logic, for each attribute `NAME` the callee carries, plus the call's `markedCallerAttr`:
+
+- **Callee carries `NAME`, call NOT marked** → error E2 ("must be marked `foo.NAME(...)`").
+- **Call marked `NAME`, callee does NOT carry `NAME`** (and isn't fake-`NAME`) → error E3 ("`foo` is not a `@NAME` function").
+- **Callee carries `NAME` (non-fake), enclosing `sc.func` does NOT carry `NAME`**:
+  - explicit-only (v1): error E1 ("non-`@NAME` … cannot call `@NAME` …"), modeled on the `@nogc` message at `dmd/expressionsem.d:2204`.
+  - inferred (phase 2): record a violation and add `NAME` to `sc.func.inferredCallerAttrs`, mirroring `setGCCall`/`setGC` (`dmd/func.d:1311`,`:1291`) and the `STC.inference` flow in `semantic3` (`dmd/semantic3.d:282`).
+- **Callee is fake-`NAME`** (`callerAttrFake`): do **not** require `sc.func` to carry `NAME`, and do **not** require the caller to mark the call (the fake function is a migration boundary). Inside a fake function, internal marker requirement follows Q4 (strict default).
+
+### Phase 3 (deferred) — indirect calls, delegates, types
+Make the attribute part of `TypeFunction` (`dmd/mtype.d:3047`) so `@CTX_SWITCH void delegate()` enforces at indirect call sites; handle virtual dispatch, `opCall`, function pointers, `alias`. Mangling impact (and thus separate-compilation/migration) is decided with design-spec Q3 — **kept out of v1** so converted code links against unconverted libraries.
+
+---
+
+## 6. Diagnostics catalog
+
+| ID | Condition | Message (proposed) |
+|----|-----------|--------------------|
+| E1 | non-`@NAME` function performs a `@NAME` call | `` `@NAME` function `g` cannot be called from non-`@NAME` function `h` `` (phrased like the `@nogc` error) |
+| E2 | `@NAME` call written without the marker | `` call to `@NAME` function `foo` must be marked `foo.NAME(...)` `` |
+| E3 | `.NAME` marker on a callee that doesn't carry `NAME` | `` `foo` is not a `@NAME` function; remove the `.NAME` marker `` |
+| E4 | `.NAME` used but `NAME` alias not visible in scope | falls through to the normal "no property `NAME`" error (`:14351`) — by design (Q3) |
+
+Emit via `error(loc, ...)` (top-level), e.g. as `dmd/expressionsem.d:2204`.
+
+---
+
+## 7. Test plan
+
+Tests live under `tests/dmd/compilable/` (must compile) and `tests/dmd/fail_compilation/` (must fail), with expected errors in a `TEST_OUTPUT` block (format per `tests/dmd/fail_compilation/attributediagnostic_nogc.d`). A shared helper module declares the attribute. Line numbers in the `TEST_OUTPUT` blocks below are **illustrative** — they get finalized once the code is laid out.
+
+### Shared helper (used by all tests)
+
+```d
+// tests/dmd/compilable/imports/callerattr_defs.d  (and a copy path for fail tests)
+module callerattr_defs;
+import core.attribute : callerAttr, callerAttrFake;
+alias CTX_SWITCH      = callerAttr!"CTX_SWITCH";
+alias CTX_SWITCH_FAKE = callerAttrFake!"CTX_SWITCH";
+```
+
+### 7.1 Should compile cleanly — `tests/dmd/compilable/callerattr_ok.d`
+
+```d
+// EXPECTED: compiles with no errors
+import callerattr_defs;
+
+@CTX_SWITCH void yieldNow() {}          // a CS-capable leaf
+void plain() {}                          // not CS-capable
+
+// Propagation: a CS function may call CS functions when marked.
+@CTX_SWITCH void worker() {
+    yieldNow.CTX_SWITCH();              // OK: marker matches, worker is @CTX_SWITCH
+    plain();                            // OK: plain() is not CS, no marker needed
+}
+
+// The single root (fiber main) starts the tree.
+@CTX_SWITCH void fiberMain() {
+    worker.CTX_SWITCH();               // OK
+}
+
+// Forwarder via the FAKE escape hatch: withFunc is NOT forced onto its callers.
+@CTX_SWITCH_FAKE void withLock(void delegate() dg) {
+    yieldNow.CTX_SWITCH();             // (strict-fake) internal CS call still marked
+    dg();
+}
+
+void notYetMigrated() {
+    withLock(() {});                   // OK: calling a FAKE function needs no marker
+                                        //     and does not force notYetMigrated to be @CTX_SWITCH
+}
+```
+
+### 7.2 Should compile cleanly — no-parens property form — `tests/dmd/compilable/callerattr_ok_noparens.d`
+
+```d
+// EXPECTED: compiles with no errors
+import callerattr_defs;
+
+@CTX_SWITCH void tick() {}
+
+@CTX_SWITCH void run() {
+    tick.CTX_SWITCH;                   // OK: marked zero-arg call, equivalent to tick.CTX_SWITCH()
+}
+```
+
+### 7.3 Should FAIL — unmarked CS call (E2) — `tests/dmd/fail_compilation/callerattr_unmarked.d`
+
+```d
+/*
+TEST_OUTPUT:
+---
+fail_compilation/callerattr_unmarked.d(11): Error: call to `@CTX_SWITCH` function `yieldNow` must be marked `yieldNow.CTX_SWITCH(...)`
+---
+*/
+import callerattr_defs;
+
+@CTX_SWITCH void yieldNow() {}
+
+@CTX_SWITCH void worker() {
+    yieldNow();                        // ERROR E2: missing the .CTX_SWITCH marker
+}
+```
+
+### 7.4 Should FAIL — non-CS caller calls CS callee (E1) — `tests/dmd/fail_compilation/callerattr_propagation.d`
+
+```d
+/*
+TEST_OUTPUT:
+---
+fail_compilation/callerattr_propagation.d(11): Error: `@CTX_SWITCH` function `yieldNow` cannot be called from non-`@CTX_SWITCH` function `oops`
+---
+*/
+import callerattr_defs;
+
+@CTX_SWITCH void yieldNow() {}
+
+void oops() {                          // not @CTX_SWITCH
+    yieldNow.CTX_SWITCH();             // ERROR E1: oops must itself be @CTX_SWITCH
+}
+```
+
+### 7.5 Should FAIL — marker on a non-CS function (E3) — `tests/dmd/fail_compilation/callerattr_bogus_marker.d`
+
+```d
+/*
+TEST_OUTPUT:
+---
+fail_compilation/callerattr_bogus_marker.d(11): Error: `plain` is not a `@CTX_SWITCH` function; remove the `.CTX_SWITCH` marker
+---
+*/
+import callerattr_defs;
+
+void plain() {}
+
+@CTX_SWITCH void caller() {
+    plain.CTX_SWITCH();                // ERROR E3: plain() does not carry CTX_SWITCH
+}
+```
+
+### 7.6 Should FAIL — collision falls back to member lookup (E4, Q6c) — `tests/dmd/fail_compilation/callerattr_collision.d`
+
+```d
+/*
+TEST_OUTPUT:
+---
+fail_compilation/callerattr_collision.d(13): Error: no property `CTX_SWITCH` for `s` of type `S`
+---
+*/
+import callerattr_defs;
+
+struct S { void run() {} }             // S has no member CTX_SWITCH
+
+void f() {
+    S s;
+    s.CTX_SWITCH();                    // Per Q6c: `s` is not callable as a CS marker target,
+                                        // and S has no member CTX_SWITCH -> normal member error
+}
+```
+
+> 7.6 documents the chosen collision behavior; if Q6 selects rule (a) or (b) the expected output changes accordingly.
+
+---
+
+## 8. Risks & open implementation issues
+
+- **Interception ordering vs. UFCS.** The marker check must run before UFCS turns `callee.NAME` into `NAME(callee)`. `resolveUFCS` (`:1087`) is the right chokepoint, but the no-parens `DotIdExp` path (`:8110`) is separate and must be handled too — easy to miss one and get inconsistent behavior.
+- **CTFE vs. template-arg extraction for the name.** Q1a (type-per-name) avoids CTFE and is the lower-risk path; Q1b needs reliable CTFE of the UDA at the point of checking.
+- **Inference complexity (phase 2).** Wiring a new inferred attribute into the `STC.inference`/`semantic3` machinery is the hardest part; explicit-only v1 sidesteps it (Q2).
+- **`__traits` / reflection.** Expose "carries caller-attr X" so tooling/tests can introspect; low effort, do alongside phase 0.
+- **Error-message line stability.** `TEST_OUTPUT` blocks are line-sensitive; finalize messages early to avoid churning the test files.
+
+---
+
+## 9. Suggested landing order
+
+1. Phase 0 + Phase 1 + Phase 2 (explicit-only), with tests 7.1, 7.3–7.6 → a usable, enforced feature for direct calls.
+2. Add 7.2 (no-parens) and `__traits` support.
+3. Phase 2 inference (if Q2 wants it) + the fake/strict tests.
+4. Phase 3 (delegates/types/virtual) + mangling decision.
+
+---
+
+## Implementation status
+
+Implemented and verified against the modified compiler (`build/bin/ldc2`, DMD 2.108.1 base). Phases 0–2 (explicit-only, direct calls + aggregate methods) are done.
+
+### Files changed
+- `runtime/druntime/src/core/attribute.d` — added the `callerAttr(string, bool=false)` struct template and the `callerAttrFake` alias.
+- `dmd/id.d` — added `udaCallerAttr` → `"callerAttr"`.
+- `dmd/attrib.d` — added `isCallerAttrStruct` / `isCallerAttrExp` recognition helpers (+ `dmd.dstruct`/`dmd.dtemplate` imports).
+- `dmd/expression.d` — added `CallExp.markedCallerAttr` (the `.ATTR` marker recorded at a call site).
+- `dmd/expressionsem.d` —
+  - `resolveUFCS`: intercept `callee.ATTR(args)` and rewrite to a marked plain call;
+  - `visit(DotIdExp)`: intercept the no-parens `callee.ATTR;` form;
+  - `callerAttrMarkerName`, `symCarriesCallerAttr`, `callerAttrCalleeVar`, `checkCallerAttr` helpers (`checkCallerAttr` takes any UDA-carrying `Dsymbol` — a `FuncDeclaration` for direct calls or the delegate/function-pointer `VarDeclaration` for indirect calls);
+  - wired `checkCallerAttr` into the `CallExp` path: `checkFunctionAttributes` for the VarExp/most branches, the DotVar method-call branch, and the `t1.ty != Tfunction` branch for delegate / function-pointer calls.
+
+### Verified behavior
+- `tests/dmd/compilable/callerattr.d` — compiles cleanly (propagation chain, fake forwarder, no-parens form, aggregate methods).
+- `tests/dmd/fail_compilation/callerattr_unmarked.d` (E2):
+  `` Error: call to `@CTX_SWITCH` function `…yieldNow` must be marked `yieldNow.CTX_SWITCH(...)` ``
+- `tests/dmd/fail_compilation/callerattr_propagation.d` (E1):
+  `` Error: non-`@CTX_SWITCH` function `…oops` cannot call `@CTX_SWITCH` function `…yieldNow` ``
+- `tests/dmd/fail_compilation/callerattr_badmarker.d` (E3):
+  `` Error: `…plain` is not a `@CTX_SWITCH` function; remove the `.CTX_SWITCH` marker ``
+
+- `tests/dmd/fail_compilation/callerattr_delegate.d` — indirect (delegate / function-pointer) calls: unmarked `@CTX_SWITCH` delegate (E2, incl. `scope`), non-CS caller (E1), stray marker on a plain delegate (E3).
+
+Each fail test's `TEST_OUTPUT` block matches the compiler's actual output (path + line + message). Regression: member-access/UFCS/template-heavy and delegate/range-heavy `core.*`/`std.*` modules — including `core.thread.fiber`, `std.algorithm.*`, `std.range`, `std.functional` — still compile unchanged (no false positives from the indirect-call check). `scope` and non-`scope` delegate parameters enforce identically.
+
+### Known limitations (deferred)
+- No inference (explicit annotation required on every non-root function on the chain); in particular a CS lambda can't yet be annotated, so lambdas can't make marked calls.
+- Caller-attrs are not encoded in the delegate/function-pointer *type*, only on the parameter declaration. So the indirect *call* is enforced, but passing a non-CS callable into a `@CTX_SWITCH` delegate parameter is not value-side checked (needs `TypeFunction` work). Indirect calls through a delegate that isn't a simple variable/field (e.g. one returned from a call) aren't gated.
+- Collision refinement (a real member sharing a `callerAttr` alias name) not handled — a visible alias always wins.
+- Attribute does not affect mangling (intentional, so converted code links against unconverted libraries).

--- a/docs/ctx-switch-option-a-implementation-spec.md
+++ b/docs/ctx-switch-option-a-implementation-spec.md
@@ -1,9 +1,10 @@
-# Implementation Spec: Option A — Caller-Required Attributes with `.ATTR` Call-Site Marker
+# Implementation Spec: Caller-Required Attributes with the `() @ATTR` Call-Site Marker
 
 **Status:** ✅ Implemented & verified in this tree (Weka-local fork). See [Implementation status](#implementation-status).
-**Implements:** Option A from [`ctx-switch-marking-spec.md`](./ctx-switch-marking-spec.md) — the generalized `callerAttr` facility with the member-access call-site marker (`callee.CTX_SWITCH(args)`).
+**Implements:** the generalized `callerAttr` facility from [`ctx-switch-marking-spec.md`](./ctx-switch-marking-spec.md).
 **Target:** Weka-local fork of the LDC/DMD frontend (`dmd/`). No upstreaming constraint.
-**Non-goal:** the `@ATTR` spelling (Option B) — explicitly out of scope here.
+
+> **Call-site syntax (updated):** the marker is now a **postfix attribute on the call**, `callee(args) @CTX_SWITCH`, rather than the earlier member-access form `callee.CTX_SWITCH(args)`. This required a parser change (new expression grammar: `PostfixExpression '@' Identifier`). **Tooling tradeoff:** unlike the member-access form (which parsed with existing grammars), this `@`-postfix syntax is *intrusive* to third-party D parsers (libdparse/DCD/serve-d/dfmt/etc.) until they are taught the grammar — i.e. it has the same ecosystem cost as design-spec Option B/D2. Everything below that refers to "the `.ATTR` marker" now means the `() @ATTR` postfix marker.
 
 All file:line references below were verified against the current tree.
 

--- a/runtime/druntime/src/core/attribute.d
+++ b/runtime/druntime/src/core/attribute.d
@@ -302,3 +302,37 @@ enum mustuse;
  * This is only allowed on `shared` static constructors, not thread-local module constructors.
  */
 enum standalone;
+
+/**
+ * Option A — caller-required attributes (Weka extension).
+ *
+ * `callerAttr!"NAME"` produces a compiler-recognized UDA type. A function tagged
+ * with such a UDA "carries" the named caller-required attribute; every call to it
+ * must be written with the member-access marker `callee.NAME(args)`, and the
+ * enclosing function must itself carry `NAME` (the property propagates upward to
+ * a single declared root). `callerAttrFake!"NAME"` is the migration variant: it
+ * carries the attribute for forwarding but does not force the requirement onto
+ * its callers.
+ *
+ * Example:
+ * ---
+ * import core.attribute : callerAttr, callerAttrFake;
+ * alias CTX_SWITCH      = callerAttr!"CTX_SWITCH";
+ * alias CTX_SWITCH_FAKE = callerAttrFake!"CTX_SWITCH";
+ *
+ * @CTX_SWITCH void yieldNow() {}
+ * @CTX_SWITCH void worker() { yieldNow.CTX_SWITCH(); }   // ok
+ * void bad()                { yieldNow.CTX_SWITCH(); }   // error: bad is not @CTX_SWITCH
+ * ---
+ */
+struct callerAttr(string name_, bool fake_ = false)
+{
+    enum string name = name_;
+    enum bool fake = fake_;
+}
+
+/// ditto
+template callerAttrFake(string name_)
+{
+    alias callerAttrFake = callerAttr!(name_, true);
+}

--- a/tests/dmd/compilable/callerattr.d
+++ b/tests/dmd/compilable/callerattr.d
@@ -143,3 +143,75 @@ void usesDelegates()
     each(() {});               // plain delegate: no marker
     eachScoped(() {});
 }
+
+// ----------------------------------------------------------------------------
+// Regression: the call-site marker must survive template instantiation.
+// CallExp.markedCallerAttr is set at parse time, so CallExp.syntaxCopy() must
+// copy it — otherwise each template instantiation loses the marker and wrongly
+// reports "call must be marked". A FAKE template instantiated with >1 arg keeps
+// its internal marker across all instantiations.
+@CTX_SWITCH_FAKE void suspendThisFiberT(bool withDelayFault = true)()
+{
+    yieldNow() @CTX_SWITCH;     // marker inside a templated body
+}
+void drivesTemplate()
+{
+    suspendThisFiberT!(true)();
+    suspendThisFiberT!(false)();
+}
+
+// ----------------------------------------------------------------------------
+// foreach over an aggregate's opApply: the loop body is lowered to a delegate passed to opApply.
+// A container can offer both a plain and a @CTX_SWITCH opApply; the caller-attr overload tie-break
+// picks per body, and a context-switching body propagates @CTX_SWITCH to the enclosing function
+// (the compiler-generated foreach->opApply call is implicitly marked — no user marker possible).
+struct CtxContainer
+{
+    int[2] data;
+    // plain iteration
+    int opApply(scope int delegate(int) dg)
+    {
+        foreach (x; data) { if (auto r = dg(x)) return r; }
+        return 0;
+    }
+    // context-switching iteration (chosen when the loop body calls a @CTX_SWITCH function)
+    @CTX_SWITCH int opApply(scope @CTX_SWITCH int delegate(int) dg)
+    {
+        foreach (x; data) { if (auto r = dg(x) @CTX_SWITCH) return r; }
+        return 0;
+    }
+}
+
+// plain body -> selects the plain opApply; no propagation, callable from non-@CTX_SWITCH code.
+void foreachPlain()
+{
+    CtxContainer c;
+    foreach (x; c) { int y = x; }
+}
+
+// context-switching body -> selects the @CTX_SWITCH opApply; the marker stays natural and the
+// enclosing function must itself be @CTX_SWITCH (propagation through foreach).
+@CTX_SWITCH void foreachCtxSwitch()
+{
+    CtxContainer c;
+    foreach (x; c) { yieldNow() @CTX_SWITCH; }
+}
+
+// a FAKE function may host a context-switching foreach without forcing the requirement on its callers.
+@CTX_SWITCH_FAKE void foreachCtxSwitchFake()
+{
+    CtxContainer c;
+    foreach (x; c) { yieldNow() @CTX_SWITCH; }
+}
+void drivesForeachFake() { foreachCtxSwitchFake(); }   // calling a FAKE: no marker, no propagation
+
+// A @CTX_SWITCH function may freely run ordinary (non-context-switching) foreach loops: a plain body
+// selects the plain opApply, so the loop needs no marker and does not itself re-propagate. (This
+// function is @CTX_SWITCH for its own reasons — the direct marked call below.)
+@CTX_SWITCH void ctxFnWithPlainForeach()
+{
+    CtxContainer c;
+    int sum;
+    foreach (x; c) { sum += x; }    // plain body -> plain opApply, no @CTX_SWITCH involved
+    yieldNow() @CTX_SWITCH;          // the genuine context switch
+}

--- a/tests/dmd/compilable/callerattr.d
+++ b/tests/dmd/compilable/callerattr.d
@@ -1,4 +1,4 @@
-// Option A: caller-required attributes with the `.ATTR` member-access marker.
+// Option A: caller-required attributes with the postfix `() @ATTR` call-site marker.
 // These all compile cleanly.
 import core.attribute : callerAttr, callerAttrFake;
 alias CTX_SWITCH      = callerAttr!"CTX_SWITCH";
@@ -10,47 +10,40 @@ void plain() {}
 // Propagation: a @CTX_SWITCH function may call @CTX_SWITCH functions when marked.
 @CTX_SWITCH void worker()
 {
-    yieldNow.CTX_SWITCH();   // marker matches; worker is @CTX_SWITCH
-    plain();                 // not CS, no marker needed
+    yieldNow() @CTX_SWITCH;   // marker matches; worker is @CTX_SWITCH
+    plain();                  // not CS, no marker needed
 }
 
 // The single root (e.g. the fiber main) starts the tree.
 @CTX_SWITCH void fiberMain()
 {
-    worker.CTX_SWITCH();
+    worker() @CTX_SWITCH;
 }
 
 // Forwarder via the FAKE migration shim: not forced onto its callers.
 @CTX_SWITCH_FAKE void withLock(void delegate() dg)
 {
-    yieldNow.CTX_SWITCH();   // strict-fake: internal CS call still marked
+    yieldNow() @CTX_SWITCH;   // strict-fake: internal CS call still marked
     dg();
 }
 
 void notYetMigrated()
 {
-    withLock(() {});         // calling a FAKE function needs no marker and no propagation
-}
-
-// No-parens property form is a marked zero-arg call.
-@CTX_SWITCH void tick() {}
-@CTX_SWITCH void run()
-{
-    tick.CTX_SWITCH;
+    withLock(() {});          // calling a FAKE function needs no marker and no propagation
 }
 
 // Works on aggregate methods too.
 struct Fiber
 {
     @CTX_SWITCH void yield() {}
-    @CTX_SWITCH void step() { this.yield.CTX_SWITCH(); }
+    @CTX_SWITCH void step() { this.yield() @CTX_SWITCH; }
 }
 
 // ----------------------------------------------------------------------------
 // Delegates / function pointers (indirect calls).
 //
 // A delegate parameter marked `@CTX_SWITCH` is itself a context-switching callee:
-// calling it requires the `.CTX_SWITCH` marker and propagates upward exactly like
+// calling it requires the `() @CTX_SWITCH` marker and propagates upward exactly like
 // a named function. This holds whether or not the parameter is `scope`.
 // A delegate parameter *without* `@CTX_SWITCH` is an ordinary callee: no marker,
 // no propagation.
@@ -60,26 +53,26 @@ struct Fiber
 // Non-scope @CTX_SWITCH delegate, forwarded by a FAKE shim (no propagation to callers).
 @CTX_SWITCH_FAKE void withDg(@CTX_SWITCH void delegate() dg)
 {
-    yieldNow.CTX_SWITCH();
-    dg.CTX_SWITCH();             // marked indirect call
+    yieldNow() @CTX_SWITCH;
+    dg() @CTX_SWITCH;             // marked indirect call
 }
 
 // `scope` @CTX_SWITCH delegate — same rules; `scope` does not change enforcement.
 @CTX_SWITCH_FAKE void withScopeDg(@CTX_SWITCH scope void delegate() dg)
 {
-    dg.CTX_SWITCH();
+    dg() @CTX_SWITCH;
 }
 
 // A real @CTX_SWITCH function calling a @CTX_SWITCH (scope) delegate: propagation holds.
 @CTX_SWITCH void runScoped(@CTX_SWITCH scope void delegate() dg)
 {
-    dg.CTX_SWITCH();
+    dg() @CTX_SWITCH;
 }
 
 // @CTX_SWITCH function-pointer parameter, called with the marker.
 @CTX_SWITCH void runFp(@CTX_SWITCH void function() fp)
 {
-    fp.CTX_SWITCH();
+    fp() @CTX_SWITCH;
 }
 
 // (A context-switching lambda passed to a *plain* delegate parameter is rejected —
@@ -88,17 +81,17 @@ struct Fiber
 // Both kinds side by side: `dg` requires the marker, `dg_no_ctx` does not.
 @CTX_SWITCH void runMixed(@CTX_SWITCH void delegate() dg, void delegate() dg_no_ctx)
 {
-    withDg.CTX_SWITCH(dg);
+    withDg(dg) @CTX_SWITCH;
 
     // An in-place lambda that itself performs a context switch. The lambda infers
     // `@CTX_SWITCH` from its body (like @nogc/@safe inference), so no annotation
     // and no FAKE shim are needed.
-    withDg.CTX_SWITCH(() {
-        yieldNow.CTX_SWITCH();
-    });
+    withDg(() {
+        yieldNow() @CTX_SWITCH;
+    }) @CTX_SWITCH;
 
-    dg.CTX_SWITCH();   // CS delegate: marker required
-    dg_no_ctx();       // plain delegate: no marker
+    dg() @CTX_SWITCH;   // CS delegate: marker required
+    dg_no_ctx();        // plain delegate: no marker
 }
 
 // --- delegates that DO NOT require CTX_SWITCH ---
@@ -125,9 +118,7 @@ void withDgPlain(void delegate() dg)
 
 void usesWithDgPlain()
 {
-    withDgPlain(() {
-        // yieldNow.CTX_SWITCH(); // build error here [cannot pass `@CTX_SWITCH` lambda to non-`@CTX_SWITCH` parameter `dg`]
-    }); 
+    withDgPlain(() {});   // plain lambda: no context switch, no marker
 }
 
 // IMPORTANT (the core safety rule): a function NOT marked @CTX_SWITCH may NOT call a
@@ -135,12 +126,12 @@ void usesWithDgPlain()
 // covered by fail_compilation/callerattr_propagation.d and callerattr_delegate.d:
 //
 //   void illegalNamed() {
-//       yieldNow.CTX_SWITCH();   // Error: non-`@CTX_SWITCH` function `illegalNamed`
-//                                //        cannot call `@CTX_SWITCH` function `yieldNow`
+//       yieldNow() @CTX_SWITCH;   // Error: non-`@CTX_SWITCH` function `illegalNamed`
+//                                 //        cannot call `@CTX_SWITCH` function `yieldNow`
 //   }
 //   void illegalDg(@CTX_SWITCH void delegate() dg) {
-//       dg.CTX_SWITCH();         // Error: non-`@CTX_SWITCH` function `illegalDg`
-//                                //        cannot call `@CTX_SWITCH` function `illegalDg.dg`
+//       dg() @CTX_SWITCH;         // Error: non-`@CTX_SWITCH` function `illegalDg`
+//                                 //        cannot call `@CTX_SWITCH` function `illegalDg.dg`
 //   }
 
 // Driving both kinds from non-CS code: calling a FAKE forwarder needs no marker
@@ -152,4 +143,3 @@ void usesDelegates()
     each(() {});               // plain delegate: no marker
     eachScoped(() {});
 }
-

--- a/tests/dmd/compilable/callerattr.d
+++ b/tests/dmd/compilable/callerattr.d
@@ -1,0 +1,155 @@
+// Option A: caller-required attributes with the `.ATTR` member-access marker.
+// These all compile cleanly.
+import core.attribute : callerAttr, callerAttrFake;
+alias CTX_SWITCH      = callerAttr!"CTX_SWITCH";
+alias CTX_SWITCH_FAKE = callerAttrFake!"CTX_SWITCH";
+
+@CTX_SWITCH void yieldNow() {}
+void plain() {}
+
+// Propagation: a @CTX_SWITCH function may call @CTX_SWITCH functions when marked.
+@CTX_SWITCH void worker()
+{
+    yieldNow.CTX_SWITCH();   // marker matches; worker is @CTX_SWITCH
+    plain();                 // not CS, no marker needed
+}
+
+// The single root (e.g. the fiber main) starts the tree.
+@CTX_SWITCH void fiberMain()
+{
+    worker.CTX_SWITCH();
+}
+
+// Forwarder via the FAKE migration shim: not forced onto its callers.
+@CTX_SWITCH_FAKE void withLock(void delegate() dg)
+{
+    yieldNow.CTX_SWITCH();   // strict-fake: internal CS call still marked
+    dg();
+}
+
+void notYetMigrated()
+{
+    withLock(() {});         // calling a FAKE function needs no marker and no propagation
+}
+
+// No-parens property form is a marked zero-arg call.
+@CTX_SWITCH void tick() {}
+@CTX_SWITCH void run()
+{
+    tick.CTX_SWITCH;
+}
+
+// Works on aggregate methods too.
+struct Fiber
+{
+    @CTX_SWITCH void yield() {}
+    @CTX_SWITCH void step() { this.yield.CTX_SWITCH(); }
+}
+
+// ----------------------------------------------------------------------------
+// Delegates / function pointers (indirect calls).
+//
+// A delegate parameter marked `@CTX_SWITCH` is itself a context-switching callee:
+// calling it requires the `.CTX_SWITCH` marker and propagates upward exactly like
+// a named function. This holds whether or not the parameter is `scope`.
+// A delegate parameter *without* `@CTX_SWITCH` is an ordinary callee: no marker,
+// no propagation.
+
+// --- delegates that REQUIRE CTX_SWITCH ---
+
+// Non-scope @CTX_SWITCH delegate, forwarded by a FAKE shim (no propagation to callers).
+@CTX_SWITCH_FAKE void withDg(@CTX_SWITCH void delegate() dg)
+{
+    yieldNow.CTX_SWITCH();
+    dg.CTX_SWITCH();             // marked indirect call
+}
+
+// `scope` @CTX_SWITCH delegate — same rules; `scope` does not change enforcement.
+@CTX_SWITCH_FAKE void withScopeDg(@CTX_SWITCH scope void delegate() dg)
+{
+    dg.CTX_SWITCH();
+}
+
+// A real @CTX_SWITCH function calling a @CTX_SWITCH (scope) delegate: propagation holds.
+@CTX_SWITCH void runScoped(@CTX_SWITCH scope void delegate() dg)
+{
+    dg.CTX_SWITCH();
+}
+
+// @CTX_SWITCH function-pointer parameter, called with the marker.
+@CTX_SWITCH void runFp(@CTX_SWITCH void function() fp)
+{
+    fp.CTX_SWITCH();
+}
+
+// (A context-switching lambda passed to a *plain* delegate parameter is rejected —
+// see fail_compilation/callerattr_lambda_leak.d.)
+
+// Both kinds side by side: `dg` requires the marker, `dg_no_ctx` does not.
+@CTX_SWITCH void runMixed(@CTX_SWITCH void delegate() dg, void delegate() dg_no_ctx)
+{
+    withDg.CTX_SWITCH(dg);
+
+    // An in-place lambda that itself performs a context switch. The lambda infers
+    // `@CTX_SWITCH` from its body (like @nogc/@safe inference), so no annotation
+    // and no FAKE shim are needed.
+    withDg.CTX_SWITCH(() {
+        yieldNow.CTX_SWITCH();
+    });
+
+    dg.CTX_SWITCH();   // CS delegate: marker required
+    dg_no_ctx();       // plain delegate: no marker
+}
+
+// --- delegates that DO NOT require CTX_SWITCH ---
+
+// Plain delegates (scope and non-scope): ordinary callees, no marker, callable
+// from non-@CTX_SWITCH code.
+void eachScoped(scope void delegate() dg) { dg(); }
+void each(void delegate() dg)             { dg(); }
+
+// A non-@CTX_SWITCH function receiving a non-@CTX_SWITCH delegate: nothing here is
+// context-switching, so no marker is needed and the function need not be @CTX_SWITCH.
+void runPlain(void delegate() dg_no_ctx)
+{
+    dg_no_ctx();
+}
+
+// A non-@CTX_SWITCH function that calls a plain delegate (no context switch): fine.
+// (Passing a *context-switching* lambda here is rejected — see
+// fail_compilation/callerattr_lambda_leak.d.)
+void withDgPlain(void delegate() dg)
+{
+    dg();
+}
+
+void usesWithDgPlain()
+{
+    withDgPlain(() {
+        // yieldNow.CTX_SWITCH(); // build error here [cannot pass `@CTX_SWITCH` lambda to non-`@CTX_SWITCH` parameter `dg`]
+    }); 
+}
+
+// IMPORTANT (the core safety rule): a function NOT marked @CTX_SWITCH may NOT call a
+// @CTX_SWITCH callee. Each commented line below is a compile error — enforced and
+// covered by fail_compilation/callerattr_propagation.d and callerattr_delegate.d:
+//
+//   void illegalNamed() {
+//       yieldNow.CTX_SWITCH();   // Error: non-`@CTX_SWITCH` function `illegalNamed`
+//                                //        cannot call `@CTX_SWITCH` function `yieldNow`
+//   }
+//   void illegalDg(@CTX_SWITCH void delegate() dg) {
+//       dg.CTX_SWITCH();         // Error: non-`@CTX_SWITCH` function `illegalDg`
+//                                //        cannot call `@CTX_SWITCH` function `illegalDg.dg`
+//   }
+
+// Driving both kinds from non-CS code: calling a FAKE forwarder needs no marker
+// and does not force the caller to be @CTX_SWITCH; plain delegates need no marker.
+void usesDelegates()
+{
+    withDg(() {});              // FAKE forwarder: no marker, no propagation
+    withScopeDg(() {});
+    each(() {});               // plain delegate: no marker
+    eachScoped(() {});
+}
+

--- a/tests/dmd/fail_compilation/callerattr_badmarker.d
+++ b/tests/dmd/fail_compilation/callerattr_badmarker.d
@@ -1,0 +1,16 @@
+import core.attribute : callerAttr;
+alias CTX_SWITCH = callerAttr!"CTX_SWITCH";
+
+void plain() {}
+
+@CTX_SWITCH void caller()
+{
+    plain.CTX_SWITCH();   // error: plain is not a @CTX_SWITCH function
+}
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/callerattr_badmarker.d(8): Error: `callerattr_badmarker.plain` is not a `@CTX_SWITCH` function; remove the `.CTX_SWITCH` marker
+---
+*/

--- a/tests/dmd/fail_compilation/callerattr_badmarker.d
+++ b/tests/dmd/fail_compilation/callerattr_badmarker.d
@@ -5,12 +5,12 @@ void plain() {}
 
 @CTX_SWITCH void caller()
 {
-    plain.CTX_SWITCH();   // error: plain is not a @CTX_SWITCH function
+    plain() @CTX_SWITCH;   // error: plain is not a @CTX_SWITCH function
 }
 
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/callerattr_badmarker.d(8): Error: `callerattr_badmarker.plain` is not a `@CTX_SWITCH` function; remove the `.CTX_SWITCH` marker
+fail_compilation/callerattr_badmarker.d(8): Error: `callerattr_badmarker.plain` is not a `@CTX_SWITCH` function; remove the `@CTX_SWITCH` marker
 ---
 */

--- a/tests/dmd/fail_compilation/callerattr_delegate.d
+++ b/tests/dmd/fail_compilation/callerattr_delegate.d
@@ -1,0 +1,38 @@
+// Caller-required attributes on delegate / function-pointer parameters (indirect calls).
+import core.attribute : callerAttr, callerAttrFake;
+alias CTX_SWITCH      = callerAttr!"CTX_SWITCH";
+alias CTX_SWITCH_FAKE = callerAttrFake!"CTX_SWITCH";
+
+// E2: a @CTX_SWITCH delegate called without the marker.
+@CTX_SWITCH_FAKE void unmarked(@CTX_SWITCH void delegate() dg)
+{
+    dg();
+}
+
+// E2 with `scope`: scope does not change enforcement.
+@CTX_SWITCH_FAKE void unmarkedScope(@CTX_SWITCH scope void delegate() dg)
+{
+    dg();
+}
+
+// E1: a non-@CTX_SWITCH function calling a @CTX_SWITCH delegate (marked).
+void notCs(@CTX_SWITCH void delegate() dg)
+{
+    dg.CTX_SWITCH();
+}
+
+// E3: a marker on a plain delegate that carries no caller-attribute.
+@CTX_SWITCH void bogus(void delegate() dg)
+{
+    dg.CTX_SWITCH();
+}
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/callerattr_delegate.d(9): Error: call to `@CTX_SWITCH` function `callerattr_delegate.unmarked.dg` must be marked `dg.CTX_SWITCH(...)`
+fail_compilation/callerattr_delegate.d(15): Error: call to `@CTX_SWITCH` function `callerattr_delegate.unmarkedScope.dg` must be marked `dg.CTX_SWITCH(...)`
+fail_compilation/callerattr_delegate.d(21): Error: non-`@CTX_SWITCH` function `callerattr_delegate.notCs` cannot call `@CTX_SWITCH` function `callerattr_delegate.notCs.dg`
+fail_compilation/callerattr_delegate.d(27): Error: `callerattr_delegate.bogus.dg` is not a `@CTX_SWITCH` function; remove the `.CTX_SWITCH` marker
+---
+*/

--- a/tests/dmd/fail_compilation/callerattr_delegate.d
+++ b/tests/dmd/fail_compilation/callerattr_delegate.d
@@ -18,21 +18,21 @@ alias CTX_SWITCH_FAKE = callerAttrFake!"CTX_SWITCH";
 // E1: a non-@CTX_SWITCH function calling a @CTX_SWITCH delegate (marked).
 void notCs(@CTX_SWITCH void delegate() dg)
 {
-    dg.CTX_SWITCH();
+    dg() @CTX_SWITCH;
 }
 
 // E3: a marker on a plain delegate that carries no caller-attribute.
 @CTX_SWITCH void bogus(void delegate() dg)
 {
-    dg.CTX_SWITCH();
+    dg() @CTX_SWITCH;
 }
 
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/callerattr_delegate.d(9): Error: call to `@CTX_SWITCH` function `callerattr_delegate.unmarked.dg` must be marked `dg.CTX_SWITCH(...)`
-fail_compilation/callerattr_delegate.d(15): Error: call to `@CTX_SWITCH` function `callerattr_delegate.unmarkedScope.dg` must be marked `dg.CTX_SWITCH(...)`
+fail_compilation/callerattr_delegate.d(9): Error: call to `@CTX_SWITCH` function `callerattr_delegate.unmarked.dg` must be marked `dg() @CTX_SWITCH`
+fail_compilation/callerattr_delegate.d(15): Error: call to `@CTX_SWITCH` function `callerattr_delegate.unmarkedScope.dg` must be marked `dg() @CTX_SWITCH`
 fail_compilation/callerattr_delegate.d(21): Error: non-`@CTX_SWITCH` function `callerattr_delegate.notCs` cannot call `@CTX_SWITCH` function `callerattr_delegate.notCs.dg`
-fail_compilation/callerattr_delegate.d(27): Error: `callerattr_delegate.bogus.dg` is not a `@CTX_SWITCH` function; remove the `.CTX_SWITCH` marker
+fail_compilation/callerattr_delegate.d(27): Error: `callerattr_delegate.bogus.dg` is not a `@CTX_SWITCH` function; remove the `@CTX_SWITCH` marker
 ---
 */

--- a/tests/dmd/fail_compilation/callerattr_foreach.d
+++ b/tests/dmd/fail_compilation/callerattr_foreach.d
@@ -1,0 +1,46 @@
+// A context-switching `foreach` body (lowered to a delegate passed to the aggregate's opApply)
+// propagates @CTX_SWITCH to the enclosing function: a non-@CTX_SWITCH function may not host one.
+import core.attribute : callerAttr;
+alias CTX_SWITCH = callerAttr!"CTX_SWITCH";
+
+@CTX_SWITCH void yieldNow() {}
+
+struct CtxContainer
+{
+    int[2] data;
+    
+    int opApply(scope int delegate(int) dg) { 
+        foreach (x; data) 
+            if (auto r = dg(x)) return r; 
+        return 0; 
+    }
+    
+    @CTX_SWITCH int opApply(scope @CTX_SWITCH int delegate(int) dg) { 
+        foreach (x; data) 
+            if (auto r = dg(x) @CTX_SWITCH) return r; 
+        return 0; 
+    }
+}
+
+@CTX_SWITCH void good()
+{
+    CtxContainer c;
+    foreach (x; c) { 
+        yieldNow() @CTX_SWITCH; 
+    }
+}
+
+void bad()
+{
+    CtxContainer c;
+    foreach (x; c) { 
+        yieldNow() @CTX_SWITCH; // build should fail here
+    } 
+}
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/callerattr_foreach.d(37): Error: non-`@CTX_SWITCH` function `callerattr_foreach.bad` context-switches here (via `foreach` over `@CTX_SWITCH` function `callerattr_foreach.CtxContainer.opApply`)
+---
+*/

--- a/tests/dmd/fail_compilation/callerattr_foreach_unmarked.d
+++ b/tests/dmd/fail_compilation/callerattr_foreach_unmarked.d
@@ -1,0 +1,38 @@
+// Negative cases around @CTX_SWITCH and foreach/opApply.
+import core.attribute : callerAttr;
+alias CTX_SWITCH = callerAttr!"CTX_SWITCH";
+
+@CTX_SWITCH void yieldNow() {}
+
+struct CtxContainer
+{
+    int[2] data;
+    int opApply(scope int delegate(int) dg)
+    { foreach (x; data) if (auto r = dg(x)) return r; return 0; }
+    
+    @CTX_SWITCH int opApply(scope @CTX_SWITCH int delegate(int) dg)
+    { foreach (x; data) if (auto r = dg(x) @CTX_SWITCH) return r; return 0; }
+}
+
+// (a) calling a @CTX_SWITCH function WITHOUT the marker, inside a foreach body -> must be marked (E2)
+void missingMarkerInForeach()
+{
+    CtxContainer c;
+    foreach (x; c) { 
+        yieldNow();
+    }
+}
+
+// (b) a non-@CTX_SWITCH function running a marked @CTX_SWITCH call -> cannot call (E1)
+void directCallNoAttr()
+{
+    yieldNow() @CTX_SWITCH;
+}
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/callerattr_foreach_unmarked.d(22): Error: call to `@CTX_SWITCH` function `callerattr_foreach_unmarked.yieldNow` must be marked `yieldNow() @CTX_SWITCH`
+fail_compilation/callerattr_foreach_unmarked.d(29): Error: non-`@CTX_SWITCH` function `callerattr_foreach_unmarked.directCallNoAttr` cannot call `@CTX_SWITCH` function `callerattr_foreach_unmarked.yieldNow`
+---
+*/

--- a/tests/dmd/fail_compilation/callerattr_lambda_leak.d
+++ b/tests/dmd/fail_compilation/callerattr_lambda_leak.d
@@ -1,0 +1,26 @@
+// A context-switching lambda must not leak into a non-@CTX_SWITCH delegate parameter.
+// The lambda infers @CTX_SWITCH from its body; passing it to a plain `void delegate()`
+// parameter would let a non-CS context drive a context switch, so it is rejected.
+import core.attribute : callerAttr;
+alias CTX_SWITCH = callerAttr!"CTX_SWITCH";
+
+@CTX_SWITCH void yieldNow() {}
+
+void withDgPlain(void delegate() dg)
+{
+    dg();
+}
+
+void runPlainWithLambda()
+{
+    withDgPlain(() {
+        yieldNow.CTX_SWITCH();
+    });
+}
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/callerattr_lambda_leak.d(16): Error: cannot pass `@CTX_SWITCH` lambda to non-`@CTX_SWITCH` parameter `dg`
+---
+*/

--- a/tests/dmd/fail_compilation/callerattr_lambda_leak.d
+++ b/tests/dmd/fail_compilation/callerattr_lambda_leak.d
@@ -14,7 +14,7 @@ void withDgPlain(void delegate() dg)
 void runPlainWithLambda()
 {
     withDgPlain(() {
-        yieldNow.CTX_SWITCH();
+        yieldNow() @CTX_SWITCH;
     });
 }
 

--- a/tests/dmd/fail_compilation/callerattr_propagation.d
+++ b/tests/dmd/fail_compilation/callerattr_propagation.d
@@ -5,7 +5,7 @@ alias CTX_SWITCH = callerAttr!"CTX_SWITCH";
 
 void oops()
 {
-    yieldNow.CTX_SWITCH();   // error: oops is not @CTX_SWITCH
+    yieldNow() @CTX_SWITCH;   // error: oops is not @CTX_SWITCH
 }
 
 /*

--- a/tests/dmd/fail_compilation/callerattr_propagation.d
+++ b/tests/dmd/fail_compilation/callerattr_propagation.d
@@ -1,0 +1,16 @@
+import core.attribute : callerAttr;
+alias CTX_SWITCH = callerAttr!"CTX_SWITCH";
+
+@CTX_SWITCH void yieldNow() {}
+
+void oops()
+{
+    yieldNow.CTX_SWITCH();   // error: oops is not @CTX_SWITCH
+}
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/callerattr_propagation.d(8): Error: non-`@CTX_SWITCH` function `callerattr_propagation.oops` cannot call `@CTX_SWITCH` function `callerattr_propagation.yieldNow`
+---
+*/

--- a/tests/dmd/fail_compilation/callerattr_unmarked.d
+++ b/tests/dmd/fail_compilation/callerattr_unmarked.d
@@ -1,0 +1,16 @@
+import core.attribute : callerAttr;
+alias CTX_SWITCH = callerAttr!"CTX_SWITCH";
+
+@CTX_SWITCH void yieldNow() {}
+
+@CTX_SWITCH void worker()
+{
+    yieldNow();   // error: missing the .CTX_SWITCH marker
+}
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/callerattr_unmarked.d(8): Error: call to `@CTX_SWITCH` function `callerattr_unmarked.yieldNow` must be marked `yieldNow.CTX_SWITCH(...)`
+---
+*/

--- a/tests/dmd/fail_compilation/callerattr_unmarked.d
+++ b/tests/dmd/fail_compilation/callerattr_unmarked.d
@@ -5,12 +5,12 @@ alias CTX_SWITCH = callerAttr!"CTX_SWITCH";
 
 @CTX_SWITCH void worker()
 {
-    yieldNow();   // error: missing the .CTX_SWITCH marker
+    yieldNow();   // error: missing the () @CTX_SWITCH marker
 }
 
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/callerattr_unmarked.d(8): Error: call to `@CTX_SWITCH` function `callerattr_unmarked.yieldNow` must be marked `yieldNow.CTX_SWITCH(...)`
+fail_compilation/callerattr_unmarked.d(8): Error: call to `@CTX_SWITCH` function `callerattr_unmarked.yieldNow` must be marked `yieldNow() @CTX_SWITCH`
 ---
 */


### PR DESCRIPTION
## Caller-required attributes ("Option A") — `@CTX_SWITCH`

Adds a caller-required attribute mechanism to the Weka LDC fork: a callee marked with a
caller-attribute (e.g. `@CTX_SWITCH`, defined via `core.attribute.callerAttr!"CTX_SWITCH"`)
must be acknowledged at every call site with a postfix marker, and the requirement
**propagates** to the calling function. This makes design-time-visible which call paths can
context-switch (yield a fiber), enforced by the compiler. A non-propagating variant
(`callerAttrFake`) acts as a radius limiter.

### Semantics
- **Marker (postfix):** `callee(args) @CTX_SWITCH;` — required iff `callee` carries the attribute.
  Calling a `@CTX_SWITCH` function without the marker is an error ("must be marked"); putting the
  marker on a non-`@CTX_SWITCH` callee is an error ("remove the marker").
- **Propagation:** a function calling a `@CTX_SWITCH` callee must itself be `@CTX_SWITCH` (or the
  `*_FAKE` variant, which carries the attribute but stops propagation to its own callers).
- **Delegates / function pointers:** a `@CTX_SWITCH` prefix on a delegate/function parameter type
  makes the indirect call a context-switching callee (`dg() @CTX_SWITCH`), and a context-switching
  lambda may only bind to such a parameter. Both concrete and template value parameters are supported.
- **Lambdas** infer the attribute from their body.

### Commits
1. **Add Option A caller-required attributes** — core attribute plumbing and the propagation/marker checks.
2. **Switch the marker to postfix `callee(args) @CTX_SWITCH` syntax** — ergonomic call-site syntax.
3. **foreach/opApply support + participate in name mangling** —
   - `foreach` over a context-switching `opApply` propagates the attribute to the enclosing function;
     an `opApply` that itself context-switches is marked accordingly.
   - The caller-attr now participates in name mangling, but **only** for a function that has a
     same-name/same-type overload sibling (e.g. a plain vs. `@CTX_SWITCH` `opApply` pair). This fixes
     overload-set collisions ("skipping definition … same mangled name") without breaking cross-module
     linking — standalone caller-attr functions keep their baseline mangle, since discriminating every
     caller-attr function produces inconsistent mangles across compilation units.

### Tests
- `tests/dmd/compilable/callerattr.d` — propagation, markers, delegates/function pointers, lambdas, `*_FAKE`.
- `tests/dmd/fail_compilation/callerattr_foreach.d`, `callerattr_foreach_unmarked.d` — foreach/opApply enforcement.

Validated end-to-end by building the Weka `wekanode` binary against this compiler (the migration that
adds `@CTX_SWITCH` annotations across the codebase lives in a separate wekapp branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
